### PR TITLE
Update string parser

### DIFF
--- a/src/test/parse.expression.test.ts
+++ b/src/test/parse.expression.test.ts
@@ -19,8 +19,17 @@ test("Parse Float Literal", () => {
 // <-- String Literals -->
 
 test("Parse String Literal", () => {
-    expect(EXPRESSION.string.parse("this won't work, no quotes").status).toBe(false);
-    expect(EXPRESSION.string.tryParse("\"hello\"")).toBe("hello");
+    expect(EXPRESSION.string.parse(`this won't work, no quotes`).status).toBe(false);
+    expect(EXPRESSION.string.tryParse(`"hello"`)).toBe("hello");
+
+    expect(EXPRESSION.string.tryParse(`"\\""`)).toBe('"');
+    expect(EXPRESSION.string.parse(`"\\\\""`).status).toBe(false);
+
+    // Test case which failed on old regex
+    expect(EXPRESSION.string.tryParse(`"\\\\\\""`)).toBe(`\\"`);
+
+    // Testcase for escape in regex strings.
+    expect(EXPRESSION.string.tryParse('"\\w+"')).toBe('\\w+');
 });
 
 test("Parse Empty String Literal", () => {


### PR DESCRIPTION
Hey, I tried to run Dataview on iOS and encountered #45.

This includes a new string parser which passes the previous test suite as well as a couple more tests I added to string parsing during development. It also fixes an escaping bug I encountered, namely failure to parse: `"\\\""`.  This is the first time I have encountered the `parsimmon` library so the code may not be idiomatic, any comments or improvements would be greatly appreciated.

While this passed the unit tests, I don't have any meaningful vaults to test this on (nor have I tested it on iOS) so any additional testing might be warranted.

-Josh