### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ All files have the following implicit attributes:
 - `file.ctime`: The date that the file was created.
 - `file.mtime`: The date that the file was last modified.
 
-If the file has a date inside it's title (of form `yyyy-mm-dd`), it also obtains the following attributes:
+If the file has a date inside its title (of form `yyyy-mm-dd`), it also obtains the following attributes:
 
 - `file.day`: The date contained in the file title.
 
@@ -107,7 +107,7 @@ have the following types:
 - `number`: A number like `0` or `18` or `19.37`.
 - `date`: A date and time in ISO8601 format - `yyyy-mm-ddThh:mm:ss`. Everything after the year and month is optional, so
   you can just write `yyyy-mm` or `yyyy-mm-dd` or `yyyy-mm-ddThh`. If you want to use a date in a query, use
-  `date(<date>)` where `<date>` is either a date, `today`, `tommorow`, `eom` (end of month), or `eoy` (end of year).
+  `date(<date>)` where `<date>` is either a date, `today`, `tomorrow`, `eom` (end of month), or `eoy` (end of year).
     - You can access date fields like 'years' and so on via dot-notation (i.e., `date(today).year`).
 - `duration`: A length of time - can be added/subtracted from dates. Has the format `<number> years/months/.../seconds`,
   where the unit can be years, months, weeks, days, hours, minutes, or seconds. If you want to use a duration in a


### PR DESCRIPTION
Just a couple of typos. Not sure why the Paypal link at the end shows up as changed. Vim changed the line ending perhaps?