### PR TITLE
Update rollup and package.json to the latest Obsidian "standard"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "obsidian-dataview",
-  "version": "0.2.9",
+  "version": "0.2.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.9",
+      "version": "0.2.17",
       "license": "MIT",
       "dependencies": {
         "luxon": "^1.25.0",
@@ -20,7 +20,7 @@
         "@types/node": "^14.14.2",
         "@types/parsimmon": "^1.10.6",
         "jest": "^26.6.3",
-        "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+        "obsidian": "^0.12.0",
         "rollup": "^2.32.1",
         "ts-jest": "^26.4.4",
         "tslib": "^2.0.3",
@@ -688,7 +688,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2081,8 +2080,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -3320,7 +3318,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -4332,8 +4329,8 @@
     },
     "node_modules/obsidian": {
       "version": "0.12.0",
-      "resolved": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-      "integrity": "sha512-O1rrEzbZYBBOY4QD5Jo+NGr++XjkgO22bCSA0D4OHEB0RfLlNLB+JQJQJQCsD+XY3jJ5OnMBZpbeb60McnRZmg==",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.0.tgz",
+      "integrity": "sha512-0C6xb1xfYFaFjz5Q00XS0bT5y1BSFrl75sTV/MN/gOIWIPkyTTPZAtXZIy0dAnDwwIVgE3eB60HpfUI9xiBFGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4910,9 +4907,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.45.2.tgz",
       "integrity": "sha512-kRRU7wXzFHUzBIv0GfoFFIN3m9oteY4uAsKllIpQDId5cfnkWF2J130l+27dzDju0E6MScKiV0ZM5Bw8m4blYQ==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.1"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -9973,8 +9967,9 @@
       }
     },
     "obsidian": {
-      "version": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-      "integrity": "sha512-O1rrEzbZYBBOY4QD5Jo+NGr++XjkgO22bCSA0D4OHEB0RfLlNLB+JQJQJQCsD+XY3jJ5OnMBZpbeb60McnRZmg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.0.tgz",
+      "integrity": "sha512-0C6xb1xfYFaFjz5Q00XS0bT5y1BSFrl75sTV/MN/gOIWIPkyTTPZAtXZIy0dAnDwwIVgE3eB60HpfUI9xiBFGQ==",
       "dev": true,
       "requires": {
         "@types/codemirror": "0.0.108",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
-    "build": "rollup --config rollup.config.js",
+    "build": "rollup --config rollup.config.js --environment BUILD:production",
     "test": "jest"
   },
   "keywords": [],
@@ -20,7 +20,7 @@
     "@types/node": "^14.14.2",
     "@types/parsimmon": "^1.10.6",
     "jest": "^26.6.3",
-    "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+    "obsidian": "^0.12.0",
     "rollup": "^2.32.1",
     "ts-jest": "^26.4.4",
     "tslib": "^2.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,11 +2,14 @@ import typescript from '@rollup/plugin-typescript';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
+const isProd = process.env.BUILD === "production";
+
 export default {
   input: 'src/main.ts',
   output: {
     dir: 'build',
     sourcemap: 'inline',
+    sourcemapExcludeSources: isProd,
     format: 'cjs',
     exports: 'default'
   },


### PR DESCRIPTION
Some time ago, Licat asked me to update some configuration in one of my plugin. I took the chance to update also this.

In short, this PR does:

- In `package.json`, use the official npm package instead of the github/master tarball URL.
- Do not ship source maps in "production" builds. 