### PR TITLE
Change toLiteralKey to use .path for Link

### DIFF
--- a/install-built.sh
+++ b/install-built.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 VAULT="$1"
 TARGET="$VAULT/.obsidian/plugins/dataview/"
-mkdir -p $TARGET
+mkdir -p "$TARGET"
 cp -f build/main.js styles.css manifest.json "$TARGET"
 echo Installed plugin files to "$TARGET"

--- a/src/query.ts
+++ b/src/query.ts
@@ -389,11 +389,11 @@ export namespace Fields {
 
     /** Renders an object as a string. */
     export function toLiteralKey(field: LiteralField): string {
+ debugger;
         switch (field.valueType) {
             case "string":
             case "number":
             case "null":
-            case "link":
             case "date":
             case "boolean":
                 return `${field.valueType}:${field.value}`;
@@ -405,6 +405,8 @@ export namespace Fields {
                 return `object:[${Object.entries(field.value).map(val => `${val[0]}:${toLiteralKey(val[1])}`).join(", ")}]`
             case "html":
                 return "" + field.value;
+            case "link":
+                return `${field.valueType}:${field.value.path}`;
         }
     }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -389,7 +389,6 @@ export namespace Fields {
 
     /** Renders an object as a string. */
     export function toLiteralKey(field: LiteralField): string {
- debugger;
         switch (field.valueType) {
             case "string":
             case "number":


### PR DESCRIPTION
The toLiteralKey query.ts was returning "link: [[Object]]" for every link in the array so they all sorted into the same key. Fixed that by dereferencing to the path in the "link" case.