### PR TITLE
Allow ` in inline field names. Closes #158

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ export class FullIndex {
     private async reloadInternalFile(file: TFile) {
         // TODO: Hard-coding the inline field syntax here LMAO >.>
         let newPageMeta = await extractMarkdownMetadata(file, this.vault, this.metadataCache,
-            /[_\*~]*([-0-9\w\p{Letter}\p{Emoji_Presentation}\s]+)[_\*~]*\s*::\s*(.+)/);
+            /[_\*~`]*([-0-9\w\p{Letter}\p{Emoji_Presentation}\s]+)[_\*~`]*\s*::\s*(.+)/);
 
         this.pages.set(file.path, newPageMeta);
         this.tags.set(file.path, newPageMeta.fullTags());


### PR DESCRIPTION
This allows field names to be surrounded with backticks as requested by @ngirard

```
`Key`:: value
```

Not sure if there are any reasons not to allow it but the change seemed like an easy place to dig into the dataview code!