### PR TITLE
Emit metadata ready / change events

### DIFF
--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -13,7 +13,9 @@ import { renderFileTasks, renderTasks, TaskViewLifecycle } from "src/tasks";
 import { DataArray } from "./data-array";
 
 export class DataviewApi {
-    public constructor(public app: App, public index: FullIndex, public settings: DataviewSettings) { }
+    public constructor(public app: App, public index: FullIndex, public settings: DataviewSettings) {
+        app.metadataCache.trigger("dataview:api-ready");
+    }
 
     /////////////////////////////
     // Index + Data Collection //

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -177,6 +177,8 @@ export class FullIndex {
 
             // TODO: Would like to do this on a separate thread than the index.
             for (let [_, handler] of this.reloadListeners) handler();
+
+            metadataCache.trigger("dataview:metadata-change", "rename", file, oldPath)
         });
 
         // File creation does cause a metadata change, but deletes do not. Clear the caches for this.
@@ -192,6 +194,8 @@ export class FullIndex {
 
             // TODO: Would like to do this on a separate thread than the index.
             for (let [_, handler] of this.reloadListeners) handler();
+
+            metadataCache.trigger("dataview:metadata-change", "delete", file)
         })
     }
 
@@ -251,6 +255,8 @@ export class FullIndex {
         this.etags.set(file.path, newPageMeta.tags);
         this.links.set(file.path, new Set<string>(newPageMeta.links.map(l => l.path)));
         this.folders.set(file.path, new Set<string>([getParentFolder(file.path)]));
+
+        this.metadataCache.trigger("dataview:metadata-change", "update", file);
     }
 }
 


### PR DESCRIPTION
Let me know what you think of this @blacksmithgu. It seemed more appropriate to emit events from `metadataCache` than `workspace`, but maybe I'm wrong 🤷 ?