### PR TITLE
Custom Modular Views: Move to Vault

### DIFF
--- a/src/api/inline-api.ts
+++ b/src/api/inline-api.ts
@@ -179,15 +179,12 @@ export class DataviewInlineApi {
      */
     public view(viewName: string, input: any) {
 
-        let currentFile = this.app.workspace.getActiveFile();
-        let sourcePath  = currentFile?.path ?? '';
-        
         let viewPath = `${viewName}/view.js`;
-        let viewFile = this.app.metadataCache.getFirstLinkpathDest( viewPath, sourcePath );
+        let viewFile = this.app.metadataCache.getFirstLinkpathDest( viewPath, this.currentFilePath );
 
         /** Check that a file exists for the requested view name. */
         if ( !viewFile ) {
-            renderErrorPre( this.container, `Dataview: view file not found.` );
+            renderErrorPre( this.container, `Dataview: file not found at ${viewPath}` );
             return;
         }
 
@@ -214,12 +211,14 @@ export class DataviewInlineApi {
 
         /** Check for optional CSS. */
         let cssPath = `${viewName}/view.css`;
-        let cssFile = this.app.metadataCache.getFirstLinkpathDest( cssPath, sourcePath );
+        let cssFile = this.app.metadataCache.getFirstLinkpathDest( cssPath, this.currentFilePath );
 
         if ( !cssFile ) return;
 
         this.app.vault.read(cssFile).then(viewCSS => {
             this.container.createEl('style', { text: viewCSS, attr: { scoped: '' } });
+        }).catch(error => {
+            renderErrorPre(this.container, "Dataview: " + error.stack)
         });
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownRenderChild, Plugin, Vault, MarkdownPostProcessorContext, PluginSettingTab, App, Setting, Component, FileSystemAdapter } from 'obsidian';
+import { MarkdownRenderChild, Plugin, Vault, MarkdownPostProcessorContext, PluginSettingTab, App, Setting, Component } from 'obsidian';
 import { renderErrorPre, renderList, renderTable, renderValue } from 'src/ui/render';
 import { FullIndex } from 'src/data/index';
 import * as Tasks from 'src/ui/tasks';
@@ -104,14 +104,6 @@ export default class DataviewPlugin extends Plugin {
 			}
 		});
 
-		/** Create folder for inline JS template views, if it doesn’t already exist. */
-        if (this.app.vault.adapter instanceof FileSystemAdapter) {
-			let viewsPath = `${this.app.vault.configDir}/dataviews`;
-
-			this.app.vault.adapter.exists(viewsPath).then(pathExists => {
-				if (!pathExists) this.app.vault.adapter.mkdir(viewsPath);
-			});
-        }
 	}
 
 	onunload() { }


### PR DESCRIPTION
Hello again! With the recent release of the Obsidian mobile app, I realized (and I see you did too) that my original implementation of `dv.view` won't work on mobile/web as long as it relies on file system access. This update has it fetch JS and CSS from the vault proper, instead of a hidden config file. I *believe* this will allow it to work identically on desktop, mobile & web.

There are also a few secondary benefits to this change:
- Modules can now be managed from within Obsidian.
- Module files can be synced via Obsidian Sync, as long as the user has the "sync unsupported file types" option enabled.
- `dv.view` now makes use of Obsidian’s built-in file path resolution via `getFirstLinkpathDest`, so it will behave more consistently with other Obsidian behavior, e.g. links and image paths.

Please let me know if there are any changes you'd like to see before considering this!