### PR TITLE
Add a split(string, delimiter, [limit]) function

### DIFF
--- a/docs/docs/query/functions.md
+++ b/docs/docs/query/functions.md
@@ -261,6 +261,19 @@ upper("Test") = "TEST"
 upper("test") = "TEST"
 ```
 
+### `split(string, delimiter, [limit])`
+
+Split a string on the given delimiter string. If a third argument is provided, it limits the number of splits that occur. The delimiter string is interpreted as a regular expression. If there are capture groups in the delimiter, matches are spliced into the result array, and non-matching captures are empty strings.
+
+
+```
+split("hello world", " ") = list("hello", "world")
+split("hello  world", "\s") = list("hello", "world")
+split("hello there world", " ", 2) = list("hello", "there")
+split("hello there world", "(t?here)") = list("hello ", "there", " world")
+split("hello there world", "( )(x)?") = list("hello", " ", "", "there", " ", "", "world")
+```
+
 ## Utility Functions
 
 ### `default(field, value)`

--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -503,6 +503,16 @@ export namespace DefaultFunctions {
         .vectorize(3, [0, 1, 2])
         .build();
 
+    // Ensure undefined matches turn into empty strings for split/2 and split/3.
+    const splitImpl = (str: string, delim: string, limit?: number): string[] =>
+        str.split(new RegExp(delim), limit).map(str => str || "");
+
+    /** Split a string on a given string. */
+    export const split: FunctionImpl = new FunctionBuilder("split")
+        .add2("string", "string", (string, splitter) => splitImpl(string, splitter))
+        .add3("string", "string", "number", (string, splitter, limit) => splitImpl(string, splitter, limit))
+        .build();
+
     export const fdefault = new FunctionBuilder("default")
         .add2("*", "*", (v, bk) => (Values.isNull(v) ? bk : v))
         .vectorize(2, [0, 1])
@@ -628,6 +638,7 @@ export const DEFAULT_FUNCTIONS: Record<string, FunctionImpl> = {
     replace: DefaultFunctions.replace,
     lower: DefaultFunctions.lower,
     upper: DefaultFunctions.upper,
+    split: DefaultFunctions.split,
 
     // Date Operations.
     striptime: DefaultFunctions.striptime,

--- a/src/test/function/functions.test.ts
+++ b/src/test/function/functions.test.ts
@@ -100,6 +100,27 @@ test("Evaluate lower()/upper()", () => {
     expect(parseEval('upper("hello")')).toEqual("HELLO");
 });
 
+// <-- split() -->
+
+test("Evaluate split(string, string)", () => {
+    expect(parseEval(`split("hello world", " ")`)).toEqual(parseEval(`list("hello", "world")`));
+    expect(parseEval(`split("hello world", "( )")`)).toEqual(parseEval(`list("hello", " ", "world")`));
+    expect(parseEval(`split("hello  world", "\\s+")`)).toEqual(parseEval(`list("hello", "world")`));
+    expect(parseEval(`split("hello world", "x")`)).toEqual(parseEval(`list("hello world")`));
+    expect(parseEval(`split("hello world", "( )(x)?")`)).toEqual(parseEval(`list("hello", " ", "", "world")`));
+    expect(parseEval(`split("hello there world", "(t?here)")`)).toEqual(parseEval(`list("hello ", "there", " world")`));
+    expect(parseEval(`split("hello there world", "( )(x)?")`)).toEqual(
+        parseEval(`list("hello", " ", "", "there", " ", "", "world")`)
+    );
+});
+
+test("Evaluate split(string, string, limit)", () => {
+    expect(parseEval(`split("hello world", " ", 0)`)).toEqual(parseEval(`list()`));
+    expect(parseEval(`split("hello world", " ", 1)`)).toEqual(parseEval(`list("hello")`));
+    expect(parseEval(`split("hello world", " ", 3)`)).toEqual(parseEval(`list("hello", "world")`));
+    expect(parseEval(`split("hello world", "( )", 2)`)).toEqual(parseEval(`list("hello", " ")`));
+});
+
 // <-- default() -->
 
 test("Evaluate default()", () => {


### PR DESCRIPTION
This adds a `split(string, delimiter, [limit])` function. With the exception of converting the delimiter to a regular expression and converting `undefined` matches to the empty string, it delegates to `String.prototype.split`.

This can be useful, for example, in situations where a file name may be in the format "{firstName} {lastName}" and I want to easily sort by last name.