### PR TITLE
Fix renderCompactMarkdown breaking asynchronous postprocessors

### DIFF
--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -29,8 +29,12 @@ export async function renderCompactMarkdown(
     let subcontainer = container.createSpan();
     await MarkdownRenderer.renderMarkdown(markdown, subcontainer, sourcePath, component);
 
-    if (subcontainer.children.length == 1 && subcontainer.querySelector("p")) {
-        subcontainer.innerHTML = subcontainer.querySelector("p")?.innerHTML ?? "";
+    let paragraph = subcontainer.querySelector("p");
+    if (subcontainer.children.length == 1 && paragraph) {
+        while (paragraph.firstChild) {
+            subcontainer.appendChild(paragraph.firstChild);
+        }
+        subcontainer.removeChild(paragraph);
     }
 }
 


### PR DESCRIPTION
### Problem

Current implementation of [renderCompactMarkdown](https://github.com/blacksmithgu/obsidian-dataview/blob/47ee04d0fed5a06988ed361bcc5c1eb5833f8ddf/src/ui/render.ts#L23) breaks any asynchronous postprocessing modifying DOM.

For instance, consider a postprocessor somehow modifying all internal links:
```js
plugin.registerMarkdownPostProcessor((el, ctx) => {
    el.querySelectorAll("a.internal-link").forEach(
        async (link: HTMLElement) => {
            setTimeout(() => {
                link.createSpan().innerText = "1";
            }, 50);
        }
    );
});
```

Now render a link with any method internally using `renderCompactMarkdown`:
````
```dataviewjs
dv.span(dv.fileLink(dv.currentFilePath))
```
[[Test]]
````

The link rendered by dataview won't be postprocessed.

### Solution

The described behavior is caused by the [reassignment of `.innerHTML`](https://github.com/blacksmithgu/obsidian-dataview/blob/47ee04d0fed5a06988ed361bcc5c1eb5833f8ddf/src/ui/render.ts#L33) that just moves HTML source without actually moving the nodes.

Roughly the following happens:
1. `MarkdownRenderer.renderMarkdown` renders markdown into HTML and passes it to the registered postprocessors
2. The postprocessors query the nodes from HTML and start processing them
3. `.innerHTML` is reassigned, and since the postprocessors haven't finished processing, the initial HTML is assigned, and all the nodes are created again from the old source
4. The postprocessors finish processing the nodes from non-existent HTML, and the result is not visible

I propose a more conventional way to move grandchildren to self by looping through them. As far as I know, it is the fastest of the correct implementations.