### PR TITLE
Implement #448; Add support for * tasks

### DIFF
--- a/src/data/parse/inline-field.ts
+++ b/src/data/parse/inline-field.ts
@@ -171,3 +171,26 @@ export function extractSpecialTaskFields(
 
     return result;
 }
+
+export function setInlineField(source: string, key: string, value?: string): string {
+    let existing = extractInlineFields(source);
+    let existingKeys = existing.filter(f => f.key == key);
+    let existingKey = existingKeys.length == 1 ? existingKeys[0] : undefined;
+    if (!value && !existingKey) {
+        return source;
+    }
+
+    let annotation = value ? `[${key}:: ${value}]` : "";
+    if (existingKey) {
+        let prefix = source.substring(0, existingKey.start).trimRight();
+        let suffix = source.substring(existingKey.end, source.length).trimLeft();
+        if (annotation) {
+            source = `${prefix} ${annotation} ${suffix}`;
+        } else {
+            source = `${prefix} ${suffix}`;
+        }
+    } else if (annotation) {
+        source = source.trimRight() + " " + annotation;
+    }
+    return source;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -438,6 +438,16 @@ class DataviewSettingsTab extends PluginSettingTab {
                     this.plugin.index.touch();
                 })
             );
+
+        new Setting(this.containerEl)
+            .setName("Set task completion as")
+            .setDesc("Text used as inline field key to track task completion date when toggling a task's checkbox")
+            .addText(text =>
+                text.setValue(this.plugin.settings.taskCompletionText).onChange(async value => {
+                    await this.plugin.updateSettings({ taskCompletionText: value.trim() });
+                    this.plugin.index.touch();
+                })
+            );
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,8 @@ export interface QuerySettings {
     taskLinkLocation: "start" | "end" | "none";
     /** How to render task links. If empty, will not render task links. */
     taskLinkText: string;
+    /** The name of the inline field to be added as a task's completion when checked */
+    taskCompletionText: string;
     /** If true, render a modal which shows no results were returned. */
     warnOnEmptyResult: boolean;
     /** The interval that views are refreshed, by default. */
@@ -30,6 +32,7 @@ export const DEFAULT_QUERY_SETTINGS: QuerySettings = {
     renderNullAs: "\\-",
     taskLinkLocation: "end",
     taskLinkText: "🔗",
+    taskCompletionText: "completion",
     warnOnEmptyResult: true,
     refreshInterval: 250,
     defaultDateFormat: "MMMM dd, yyyy",

--- a/src/test/parse/parse.inline.test.ts
+++ b/src/test/parse/parse.inline.test.ts
@@ -1,6 +1,6 @@
 import { EXPRESSION } from "expression/parse";
 import { Link } from "data/value";
-import { extractInlineFields } from "data/parse/inline-field";
+import { extractInlineFields, setInlineField } from "data/parse/inline-field";
 
 // <-- Inline field wierd edge cases -->
 
@@ -114,5 +114,25 @@ describe("Inline Inline With HTML", () => {
         let result = extractInlineFields(`[link:: <a href="Page">Value</a>]`);
         expect(result[0].key).toEqual("link");
         expect(result[0].value).toEqual(`<a href="Page">Value</a>`);
+    });
+});
+
+describe("Set inline", () => {
+    test("Add annotation", () => {
+        let input = "- [ ] an uncompleted task";
+        let result = setInlineField(input, "completion");
+        expect(result).toEqual(input);
+
+        result = setInlineField(input, "completion", "2021-02-21");
+        expect(result).toEqual(input + " [completion:: 2021-02-21]");
+    });
+
+    test("replace annotation", () => {
+        let input = "- [x] a completed task [completion:: 2021-02-21] foo bar";
+        let result = setInlineField(input, "completion");
+        expect(result).toEqual("- [x] a completed task foo bar");
+
+        result = setInlineField(input, "completion", "2021-02-22");
+        expect(result).toEqual("- [x] a completed task [completion:: 2021-02-22] foo bar");
     });
 });

--- a/test-vault/tasks/checklist.md
+++ b/test-vault/tasks/checklist.md
@@ -1,14 +1,14 @@
-* [ ] Normal task, tags inherited from page
+- [x] Normal task, tags inherited from page [completion:: 2021-10-23]
 * [ ] Task with a #tag, adds to inherited page tags
 	* [ ] Task that inherits tag from above and page tagssss
 * [x] Completed task ✅ 2021-08-06 📅 2021-08-07
 * [x] Completed task [completion::2021-08-06] [due::2021-08-07]
-* [ ] task with [annotation::arbitrary]
+* [ ] task with [annotation::arbitrary] [completion:: 2021-10-23] 
 * [ ] Scheduled task 📅  2021-08-07
 * [ ] Task that overrides creation date of file ➕ 2021-08-06
 * [ ] Repeating task 🔁Mondays
 * [ ] #tell @person some important thing [p::1]
-* [ ] a less important thing [p::2]
+* [x] a less important thing [p::2]
 * [ ] another important thing [p::1]
 
 #page-tag


### PR DESCRIPTION
* Sets/removes `completion` inline annotation on tasks when being checked
* Adds support for tasks in `*`-based lists