### PR TITLE
Add CALENDAR query support

### DIFF
--- a/docs/docs/query/queries.md
+++ b/docs/docs/query/queries.md
@@ -201,6 +201,25 @@ statements:
 
     - [ ] What even is a task, anyway?
 
+### Task Queries
+
+Calendar views render all pages which match the query in a calendar view, using
+the given date expression to chose which date to render a page on.
+
+=== "Syntax"
+    ```
+    CALENDAR <date>
+    FROM <source>
+    ```
+=== "Query"
+    ``` sql
+    CALENDAR file.mtime
+    FROM "dataview"
+    ```
+=== "Output"
+The output will be a calendar that displays a dot per file in the dataview
+directory. The dot will be placed on the date that the file was modified on.
+
 ## Data Commands
 
 The different commands that dataview queries can be made up of. Commands are

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "emoji-regex": "^10.0.0",
     "luxon": "^2.0.2",
+    "obsidian-calendar-ui": "^0.3.12",
     "papaparse": "^5.3.1",
     "parsimmon": "^1.18.0"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,15 @@
 import {
+    App,
+    Component,
+    MarkdownPostProcessorContext,
     MarkdownRenderChild,
     Plugin,
-    Vault,
-    MarkdownPostProcessorContext,
     PluginSettingTab,
-    App,
     Setting,
-    Component,
+    Vault,
 } from "obsidian";
+import { Calendar, ICalendarSource, IDayMetadata, IDot } from "obsidian-calendar-ui";
+import type { Moment } from "moment";
 import { renderErrorPre, renderList, renderTable, renderValue } from "ui/render";
 import { FullIndex } from "data/index";
 import * as Tasks from "ui/tasks";
@@ -15,7 +17,7 @@ import { ListQuery, Query, TableQuery } from "query/query";
 import { Field } from "expression/field";
 import { parseField } from "expression/parse";
 import { parseQuery } from "query/parse";
-import { executeInline, executeList, executeTable, executeTask } from "query/engine";
+import { executeCalendar, executeInline, executeList, executeTable, executeTask } from "query/engine";
 import { asyncTryOrPropogate, canonicalizeVarName, tryOrPropogate } from "util/normalize";
 import { asyncEvalInContext, makeApiContext } from "api/inline-api";
 import { DataviewApi } from "api/plugin-api";
@@ -138,6 +140,11 @@ export default class DataviewPlugin extends Plugin {
             case "table":
                 component.addChild(
                     new DataviewTableRenderer(query as Query, el, this.index, sourcePath, this.settings)
+                );
+                break;
+            case "calendar":
+                component.addChild(
+                    new DataviewCalendarRenderer(query as Query, el, this.index, sourcePath, this.settings, this.app)
                 );
                 break;
         }
@@ -588,6 +595,118 @@ class DataviewTableRenderer extends MarkdownRenderChild {
         if (result.data.length == 0 && this.settings.warnOnEmptyResult) {
             renderErrorPre(this.container, "Dataview: Query returned 0 results.");
         }
+    }
+}
+
+// CalendarFile is a representation of a particular file, displayed in the calendar view.
+// It'll be represented in the calendar as a dot.
+interface CalendarFile extends IDot {
+    link: Link;
+}
+
+class DataviewCalendarRenderer extends MarkdownRenderChild {
+    private calendar: Calendar;
+    constructor(
+        public query: Query,
+        public container: HTMLElement,
+        public index: FullIndex,
+        public origin: string,
+        public settings: DataviewSettings,
+        public app: App
+    ) {
+        super(container);
+    }
+
+    async onload() {
+        await this.render();
+
+        if (this.settings.refreshEnabled) {
+            onIndexChange(this.index, this.settings.refreshInterval, this, async () => {
+                this.container.innerHTML = "";
+                await this.render();
+            });
+        }
+    }
+
+    async render() {
+        let maybeResult = await asyncTryOrPropogate(() =>
+            executeCalendar(this.query, this.index, this.origin, this.settings)
+        );
+        if (!maybeResult.successful) {
+            renderErrorPre(this.container, "Dataview: " + maybeResult.error);
+            return;
+        } else if (maybeResult.value.data.length == 0 && this.settings.warnOnEmptyResult) {
+            renderErrorPre(this.container, "Dataview: Query returned 0 results.");
+            return;
+        }
+        let dateMap = new Map<string, CalendarFile[]>();
+        for (let data of maybeResult.value.data) {
+            const dot = {
+                color: "default",
+                className: "note",
+                isFilled: true,
+                link: data.link,
+            };
+            const d = data.date.toFormat("yyyyLLdd");
+            if (!dateMap.has(d)) {
+                dateMap.set(d, [dot]);
+            } else {
+                dateMap.get(d)?.push(dot);
+            }
+        }
+
+        const querySource: ICalendarSource = {
+            getDailyMetadata: async (date: Moment): Promise<IDayMetadata> => {
+                return {
+                    dots: dateMap.get(date.format("YYYYMMDD")) || [],
+                };
+            },
+        };
+
+        const sources: ICalendarSource[] = [querySource];
+        const renderer = this;
+        this.calendar = new Calendar({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            target: (this as any).container,
+            props: {
+                onHoverDay(date: Moment, targetEl: EventTarget): void {
+                    const vals = dateMap.get(date.format("YYYYMMDD"));
+                    if (!vals || vals.length == 0) {
+                        return;
+                    }
+                    if (vals?.length == 0) {
+                        return;
+                    }
+
+                    renderer.app.workspace.trigger("link-hover", {}, targetEl, vals[0].link.path, vals[0].link.path);
+                },
+                onClickDay: async date => {
+                    const vals = dateMap.get(date.format("YYYYMMDD"));
+                    if (!vals || vals.length == 0) {
+                        return;
+                    }
+                    if (vals?.length == 0) {
+                        return;
+                    }
+                    const file = renderer.app.metadataCache.getFirstLinkpathDest(vals[0].link.path, "");
+                    if (file == null) {
+                        return;
+                    }
+                    const mode = (this.app.vault as any).getConfig("defaultViewMode");
+                    const leaf = renderer.app.workspace.getUnpinnedLeaf();
+                    await leaf.openFile(file, { active: true, mode });
+                },
+                showWeekNums: false,
+                sources,
+            },
+        });
+    }
+
+    onClose(): Promise<void> {
+        if (this.calendar) {
+            this.calendar.$destroy();
+        }
+        return Promise.resolve();
     }
 }
 

--- a/src/query/parse.ts
+++ b/src/query/parse.ts
@@ -47,9 +47,9 @@ interface QueryLanguageTypes {
 export const QUERY_LANGUAGE = P.createLanguage<QueryLanguageTypes>({
     // Simple atom parsing, like words, identifiers, numbers.
     queryType: q =>
-        P.alt<string>(P.regexp(/TABLE|LIST|TASK/i))
+        P.alt<string>(P.regexp(/TABLE|LIST|TASK|CALENDAR/i))
             .map(str => str.toLowerCase() as QueryType)
-            .desc("query type ('TABLE', 'LIST', or 'TASK')"),
+            .desc("query type ('TABLE', 'LIST', 'TASK', or 'CALENDAR')"),
     explicitNamedField: q =>
         P.seqMap(
             EXPRESSION.field.skip(P.whitespace),
@@ -106,6 +106,14 @@ export const QUERY_LANGUAGE = P.createLanguage<QueryLanguageTypes>({
                     );
                 case "task":
                     return P.succeed({ type: "task" });
+                case "calendar":
+                    return P.seqMap(q.namedField, field => {
+                        return {
+                            type: "calendar",
+                            showId: true,
+                            field,
+                        };
+                    });
                 default:
                     return P.fail(`Unrecognized query type '${qtype}'`);
             }

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -3,7 +3,7 @@ import { Source } from "data/source";
 import { Field } from "expression/field";
 
 /** The supported query types (corresponding to view types). */
-export type QueryType = "list" | "table" | "task";
+export type QueryType = "list" | "table" | "task" | "calendar";
 
 /** Fields used in the query portion. */
 export interface NamedField {
@@ -59,7 +59,14 @@ export interface TaskQuery {
     type: "task";
 }
 
-export type QueryHeader = ListQuery | TableQuery | TaskQuery;
+/** A query which renders a collection of notes in a calendar view. */
+export interface CalendarQuery {
+    type: "calendar";
+    /** The date field that we'll be grouping notes by for the calendar view */
+    field: NamedField;
+}
+
+export type QueryHeader = ListQuery | TableQuery | TaskQuery | CalendarQuery;
 
 export interface WhereStep {
     type: "where";

--- a/src/test/parse/parse.query.test.ts
+++ b/src/test/parse/parse.query.test.ts
@@ -1,4 +1,4 @@
-import { TableQuery, ListQuery, SortByStep, QueryFields } from "query/query";
+import { TableQuery, ListQuery, CalendarQuery, SortByStep, QueryFields } from "query/query";
 import { QUERY_LANGUAGE, parseQuery } from "query/parse";
 import { Sources } from "data/source";
 import { DEFAULT_QUERY_SETTINGS } from "settings";
@@ -113,5 +113,16 @@ describe("Table Queries", () => {
 
         let tq = q.header as TableQuery;
         expect(tq.showId).toBe(false);
+    });
+});
+
+describe("Calendar Queries", () => {
+    test("Minimal Query", () => {
+        let simple = parseQuery("CALENDAR my-date FROM #games\n" + "WHERE foo > 100").orElseThrow();
+        expect(simple.header.type).toBe("calendar");
+        expect((simple.header as CalendarQuery).field).toEqual(
+            QueryFields.named("my-date", Fields.variable("my-date"))
+        );
+        expect(simple.source).toEqual(Sources.tag("#games"));
     });
 });

--- a/test-vault/example calendars.md
+++ b/test-vault/example calendars.md
@@ -1,0 +1,13 @@
+
+```dataview
+CALENDAR thoughtOfDate
+FROM
+"recipes"
+```
+
+
+```dataview
+CALENDAR file.mtime
+FROM
+"recipes"
+```

--- a/test-vault/recipes/pbj.md
+++ b/test-vault/recipes/pbj.md
@@ -1,6 +1,7 @@
 ---
 cuisine: American
 needsStove: false
+thoughtOfDate: 2021-12-11
 ---
 # Peanut Butter and Jelly
 ## Ingredients

--- a/test-vault/recipes/toast.md
+++ b/test-vault/recipes/toast.md
@@ -1,6 +1,7 @@
 ---
 cuisine: British
 needsStove: true
+thoughtOfDate: 2021-12-10
 ---
 
 # Toast


### PR DESCRIPTION
This commit adds support for the CALENDAR query type, which renders the
results of a dataview query in an obsidian-calendar-ui calendar.

The argument to the CALENDAR query is a date expression which controls
what day the selected note is rendered on.

Currently, each note is rendered as a dot on the calendar. Hovering or
clicking a calendar day will preview or navigate to the first selected
note on that day. Ideally, we would display the note links instead of
dots, but the calendar plugin isn't able to do this (yet).