### PR TITLE
Smart refreshing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "dataview",
   "name": "Dataview",
   "version": "0.4.21",
-  "minAppVersion": "0.12.0",
+  "minAppVersion": "0.13.11",
   "description": "Complex data views for the data-obsessed.",
   "author": "Michael Brenan <blacksmithgu@gmail.com>",
   "authorUrl": "https://github.com/blacksmithgu",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@zerollup/ts-transform-paths": "^1.7.18",
     "compare-versions": "^4.1.1",
     "jest": "^27.1.0",
-    "obsidian": "^0.12.11",
+    "obsidian": "^0.13.11",
     "prettier": "2.3.2",
     "rollup": "^2.56.3",
     "rollup-jest": "^1.1.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -321,7 +321,7 @@ class DataviewSettingsTab extends PluginSettingTab {
             )
             .addToggle(toggle =>
                 toggle.setValue(this.plugin.settings.refreshEnabled).onChange(async value => {
-                    await this.plugin.updateSettings({ warnOnEmptyResult: value });
+                    await this.plugin.updateSettings({ refreshEnabled: value });
                     this.plugin.index.touch();
                 })
             );


### PR DESCRIPTION
This PR makes it possible to change refresh settings on the fly with immediate effect for existing renderings (i.e. without navigating to new notes or switching workspaces).  It prevents refreshing when a dataview component is not mounted in the DOM (e.g. when a note is in a sidebar and the tab or sidebar is hidden), and avoids creating intervals for each dataview component.

When automatic refresh is enabled, components are re-rendered after refreshInterval milliseconds have passed since the most recent index change, or when the component is remounted in the DOM (e.g. due to revealing a sidebar note tab).  Changing the refresh interval or auto-refresh setting has immediate effect, since the signal for refreshing is now an event rather than a locally-managed setInterval.  (Switching away from setInterval to a debounced event ensures that the UI doesn't spend all its spare time refreshing when significant vault changes are taking place, or at plugin startup.)

As a practical matter, I've found that with my vault, just having a few dataview queries in sidebar note tabs makes typing slow and stuttering because of dataview constantly updating invisible views.  With this PR, the invisible views don't update, and during startup the views are updated less frequently as well, eliminating a ton of memory churn, especially of DOM elements.