### PR TITLE
Add support for querying unresolved links

### DIFF
--- a/src/data/parse/markdown-file.ts
+++ b/src/data/parse/markdown-file.ts
@@ -301,6 +301,10 @@ export function parsePage(file: TFile, cache: MetadataCache, markdownData: Parse
     if (file.path in cache.resolvedLinks) {
         for (let resolved in cache.resolvedLinks[file.path]) links.push(Link.file(resolved));
     }
+    // Also include unresolved links
+    if (file.path in cache.unresolvedLinks) {
+        for (let unresolved in cache.unresolvedLinks[file.path]) links.push(Link.file(unresolved));
+    }
 
     // Merge frontmatter fields with parsed fields.
     for (let [name, values] of markdownData.fields.entries()) {

--- a/src/data/resolver.ts
+++ b/src/data/resolver.ts
@@ -35,8 +35,10 @@ export function matchingSourcePaths(
             return Result.success(new Set());
         case "link":
             let fullPath = index.metadataCache.getFirstLinkpathDest(source.file, originFile)?.path;
-            if (!fullPath)
-                return Result.failure(`Could not resolve link "${source.file}" during link lookup - does it exist?`);
+            if (!fullPath) {
+                // Look in links which includes unresolved links
+                return Result.success(index.links.getInverse(source.file));
+            }
 
             if (source.direction === "incoming") {
                 // To find all incoming links (i.e., things that link to this), use the index that Obsidian provides.

--- a/test-vault/Books.md
+++ b/test-vault/Books.md
@@ -1,0 +1,8 @@
+# Non-Fiction
+```dataview
+list from [[Non-Fiction]]
+```
+# Fiction
+```dataview
+list from [[Fiction]]
+```

--- a/test-vault/books/Catcher in the Rye.md
+++ b/test-vault/books/Catcher in the Rye.md
@@ -1,0 +1,2 @@
+- Author: [[J.D. Salinger]]
+- Tag: [[Fiction]]

--- a/test-vault/books/Origin of Species.md
+++ b/test-vault/books/Origin of Species.md
@@ -1,0 +1,2 @@
+- Author: [[Charles Darwin]]
+- Tag: [[Non-Fiction]]

--- a/test-vault/books/The Great Gatsby.md
+++ b/test-vault/books/The Great Gatsby.md
@@ -1,0 +1,2 @@
+- Author: [[Scott Fitzgerald]]
+- Tag: [[Fiction]]


### PR DESCRIPTION
This PR adds support for querying unresolved links. This is useful for querying across links that don't yet exist, such as future dates or category links.

I've added an example where you have books with non-existent tags "Fiction" and "Non-Fiction". The idea is that eventually these pages will be filled in, but in the meantime you can already create categories from them using the all-powerful dataview 😊

## Index view of the pages

![CleanShot 2022-01-25 at 23 15 23](https://user-images.githubusercontent.com/170299/151107777-b32760f3-6848-438e-8312-f447a87ad9ac.png)

## One of the pages

![CleanShot 2022-01-25 at 23 24 10](https://user-images.githubusercontent.com/170299/151108459-b3422679-3cd3-459d-bc8a-7796d0d42044.png)

If there's interest, please let me know if there's anything else you'd like me to do get this in good shape. And don't feel bad closing if this doesn't meet your expectations or you'd like to take this in a different direction. That being said, I'm happy to implement a different solution with a bit of direction.

Closes: #303 