### PR TITLE
Fix library build missing typings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,7 +63,7 @@ const LIBRARY_CONFIG = {
     },
     plugins: getRollupPlugins(
         { tsconfig: "tsconfig-lib.json", typescript: ttypescript },
-        copy({ targets: [{ src: "src/types/*.d.ts", dest: "lib/types" }] })
+        copy({ targets: [{ src: "src/typings/*.d.ts", dest: "lib/typings" }] })
     ),
 };
 


### PR DESCRIPTION
The library published on npm lacks the typings directory; the build process apparently didn't get changed when the directory was renamed from "types", so at least the most recent npm version can't actually be used to develop plugins for the API.  This fixed it, sufficient to use a local build at least.