### PR TITLE
Vitaly/nested container

### DIFF
--- a/src/api/inline-api.ts
+++ b/src/api/inline-api.ts
@@ -15,7 +15,7 @@ import { DataArray } from "./data-array";
 
 /** Asynchronous API calls related to file / system IO. */
 export class DataviewInlineIOApi {
-    public constructor(public api: DataviewIOApi, public currentFile: string) {}
+    public constructor(public api: DataviewIOApi, public currentFile: string) { }
 
     /** Load the contents of a CSV asynchronously, returning a data array of rows (or undefined if it does not exist). */
     public async csv(path: string, originFile?: string): Promise<DataArray<DataObject> | undefined> {
@@ -189,14 +189,18 @@ export class DataviewInlineApi {
     public async el<K extends keyof HTMLElementTagNameMap>(
         el: K,
         text: any,
-        options?: DomElementInfo
+        { container = this.container, ...options }: DomElementInfo & { container?: HTMLElement | Promise<HTMLElement> } = {}
     ): Promise<HTMLElementTagNameMap[K]> {
+
         let wrapped = Values.wrapValue(text);
+
+        const parent = await Promise.resolve(container);
+
         if (wrapped === null || wrapped === undefined) {
-            return this.container.createEl(el, Object.assign({ text }, options));
+            return parent.createEl(el, Object.assign({ text }, options));
         }
 
-        let _el = this.container.createEl(el, options);
+        let _el = parent.createEl(el, options);
         await renderValue(wrapped.value, _el, this.currentFilePath, this.component, this.settings, true);
         return _el;
     }
@@ -303,7 +307,7 @@ export class DataviewInlineApi {
  * Evaluate a script where 'this' for the script is set to the given context. Allows you to define global variables.
  */
 export function evalInContext(script: string, context: any): any {
-    return function () {
+    return function() {
         return eval(script);
     }.call(context);
 }

--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -15,7 +15,7 @@ import { Context } from "expression/context";
 import { defaultLinkHandler } from "query/engine";
 import { DateTime, Duration } from "luxon";
 import * as Luxon from "luxon";
-import { compare, satisfies } from "compare-versions";
+import { compare, CompareOperator, satisfies } from "compare-versions";
 import { DvAPIInterface, DvIOAPIInterface } from "../typings/api";
 
 /** Asynchronous API calls related to file / system IO. */
@@ -81,8 +81,8 @@ export class DataviewApi implements DvAPIInterface {
             get current() {
                 return version;
             },
-            compare: (op, ver) => compare(version, ver, op),
-            satisfies: range => satisfies(version, range),
+            compare: (op: CompareOperator , ver: string) => compare(version, ver, op),
+            satisfies: (range: string) => satisfies(version, range),
         };
     })();
 

--- a/src/expression/context.ts
+++ b/src/expression/context.ts
@@ -35,7 +35,7 @@ export class Context {
         public globals: Record<string, Literal> = {},
         public binaryOps: BinaryOpHandler = createBinaryOps(linkHandler.normalize),
         public functions: Record<string, FunctionImpl> = DEFAULT_FUNCTIONS
-    ) {}
+    ) { }
 
     /** Set a global value in this context. */
     public set(name: string, value: Literal): Context {
@@ -230,7 +230,7 @@ export class Context {
                                 return Result.success(object.value.shiftTo("seconds").seconds);
                             case "millisecond":
                             case "milliseconds":
-                                return Result.success(object.value.shiftTo("millisecond").milliseconds);
+                                return Result.success(object.value.shiftTo("milliseconds").milliseconds);
                             default:
                                 return Result.success(null);
                         }


### PR DESCRIPTION
support additional option for `el` - `container` will be used instead of `this.container`.
this allows building nested html tags easily.

also:

- fixed Luton argument bug (typescript complained)
- fixed a couple of build time warnings from typescript
