### PR TITLE
[WIP] Allow emoji as first character in full-line inline fields

### DIFF
--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -144,7 +144,7 @@ const FULL_LINE_KEY_PART: P.Parser<string> = P.alt(
     .many()
     .map(parts => parts.join(""));
 
-const FULL_LINE_KEY_PARSER: P.Parser<string> = P.regexp(/[^0-9\w\p{Letter}]*/u)
+const FULL_LINE_KEY_PARSER: P.Parser<string> = P.regexp(/[^0-9\w\p{Letter}\p{Emoji_Presentation}\p{Emoji}]*/u)
     .then(FULL_LINE_KEY_PART)
     .skip(P.regexp(/[_\*~`]*/u));
 

--- a/src/test/parse/parse.inline.test.ts
+++ b/src/test/parse/parse.inline.test.ts
@@ -1,6 +1,6 @@
 import { EXPRESSION } from "expression/parse";
 import { Link } from "data-model/value";
-import { extractInlineFields, setInlineField } from "data-import/inline-field";
+import { extractFullLineField, extractInlineFields, setInlineField } from "data-import/inline-field";
 
 // <-- Inline field wierd edge cases -->
 
@@ -81,9 +81,33 @@ describe("Simple Inline Inline", () => {
             wrapping: "[",
         });
     });
+
+    test("Simple FullLine Key", () => {
+        let result = extractFullLineField("key:: value");
+        expect(result).not.toBeUndefined;
+        if (result !== undefined) {
+            expect(result.key).toEqual("key");
+            expect(result.value).toEqual("value");
+        }
+    });
 });
 
 describe("Inline Inline Edge Cases", () => {
+    test("Emoji Key in FullLine Field", () => {
+        let result = extractFullLineField("☘️:: value");
+        expect(result).not.toBeUndefined;
+        if (result !== undefined) {
+            expect(result.key).toEqual("☘️");
+            expect(result.value).toEqual("value");
+        }
+    });
+
+    test("Emoji Key", () => {
+        let result = extractInlineFields("[🍿:: value]");
+        expect(result[0].key).toEqual("🍿");
+        expect(result[0].value).toEqual("value");
+    });
+
     test("Nested Brackets", () => {
         let result = extractInlineFields("[[[[hello:: 16]]");
         expect(result[0].key).toEqual("hello");


### PR DESCRIPTION
While messing with my vault, I noted that I can use emoji as keys for inline fields if I embed them in a line (e.g., `Today I ate [🍿::50] popcorns.`). However, if I want to use the same inline field with the full line syntax (e.g., just a line with `🍿:: 50`), I get zero results.

I've played a bit to the code. I added a couple of test cases in the unit tests and I've identified a regex that fixes, at least, the difference during the parsing step.

Unfortunately, this still doesn't solve the problem. Probably there is some other place in the code I am missing.

If you think this is a valid potential fix, maybe I can use a hint to complete this PR. :)
