### PR TITLE
Update expressions.md - Add "date.weekyear" availability

### DIFF
--- a/docs/docs/query/expressions.md
+++ b/docs/docs/query/expressions.md
@@ -112,7 +112,7 @@ index operator.
 ### Dates
 
 You can retrieve various components of a date via indexing: `date.year`, `date.month`, `date.day`, `date.hour`,
-`date.minute`, `date.second`, `date.week`. You can also add durations to dates to get new dates.
+`date.minute`, `date.second`, `date.week`, `date.weekyear`. You can also add durations to dates to get new dates.
 
 ### Durations
 


### PR DESCRIPTION
I found that a query trying to restrict on date. Example "due.week = date(today).week" did not work, but in online forums found ".weekyear" is available and works perfectly. Adding it will help others discover it as well.