### PR TITLE
Emit task items that match non-dataview task lists

### DIFF
--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -49,22 +49,27 @@ function TaskItem({ item }: { item: STask }) {
         evt.stopPropagation();
 
         const completed = evt.currentTarget.checked;
+        const status = completed ? "X" : " ";
+
+        // Update data-task on the parent element (css style)
+        const parent = evt.currentTarget.parentElement;
+        parent?.setAttribute("data-task", status);
+
         let updatedText = undefined;
         if (context.settings.taskCompletionTracking)
             updatedText = setTaskCompletion(item.text, context.settings.taskCompletionText, completed);
 
-        rewriteTask(context.app.vault, item, completed ? "X" : " ", updatedText);
+        rewriteTask(context.app.vault, item, status, updatedText);
     };
 
+    const checked = item.status !== ' ';
     return (
-        <li class={"dataview task-list-item" + (item.completed ? " is-checked" : "")} onClick={onClicked}>
+        <li class={"dataview task-list-item" + (checked ? " is-checked" : "")} onClick={onClicked} data-task={item.status}>
             <input
-                style="margin-right: 6px;"
                 class="dataview task-list-item-checkbox"
                 type="checkbox"
-                checked={item.completed}
+                checked={checked}
                 onClick={onChecked}
-                data-task={item.status}
             />
             <Markdown inline={true} content={item.visual ?? item.text} sourcePath={item.path} />
             {item.children.length > 0 && <TaskList items={item.children} />}


### PR DESCRIPTION
Obsidian renders tasks like this:

For incomplete tasks:

```html
<li data-line="6" data-task="" class="task-list-item">
   <input data-line="6" type="checkbox" class="task-list-item-checkbox">
   Some text.
</li>
```

For "checked" tasks:

```html
<li data-line="6" data-task="x" class="task-list-item is-checked">
  <input data-line="6" checked type="checkbox" class="task-list-item-checkbox">
  Some text.
</li>
```

For tasks using an "alternate" completed value:

```html
<li data-line="6" data-task="/" class="task-list-item is-checked">
  <input data-line="6" checked type="checkbox" class="task-list-item-checkbox">
  Some text.
</li>
```

Note specifically where the data-task tag is, where the "is-checked" class is, and where the "checked" attribute is (or isn't) on the checkbox for the three.

This PR makes Dataview task lists consistent with that so that themes and snippet styles will apply correctly.
