### PR TITLE
Use the Task Collector modal to get completion status

### DIFF
--- a/src/typings/obsidian-ex.d.ts
+++ b/src/typings/obsidian-ex.d.ts
@@ -14,6 +14,15 @@ declare module "obsidian" {
             plugins: {
                 dataview?: {
                     api: DataviewApi;
+                },
+                "obsidian-task-collector"?: {
+                    api?: {
+                        getCompletedTaskValues(): string;
+                        getIncompleteTaskValues(): string;
+                        isComplete(value: string): boolean;
+                        isCanceled(value: string): boolean;
+                        getMark(): Promise<string>;
+                    };
                 };
             };
         };

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -55,13 +55,24 @@ function TaskItem({ item }: { item: STask }) {
         );
     };
 
-    // Check/uncheck the task in the original file.
-    const onChecked = (evt: preact.JSX.TargetedEvent<HTMLInputElement>) => {
+    const getStatus = async (previous: boolean): Promise<string> => {
+        const tcPlugin = context.app.plugins.plugins["obsidian-task-collector"];
+        if ( tcPlugin?.api ) {
+            return tcPlugin.api.getMark();
+        }
+        return previous ? "X" : " ";
+    }
+
+    // Check/uncheck trhe task in the original file.
+    const onChecked = async (evt: preact.JSX.TargetedEvent<HTMLInputElement>) => {
         evt.stopPropagation();
+
+        const target = evt.currentTarget;
         const completed = evt.currentTarget.checked;
-        const status = completed ? "x" : " ";
+        const status = await getStatus(completed);
+
         // Update data-task on the parent element (css style)
-        const parent = evt.currentTarget.parentElement;
+        const parent = target.parentElement;
         parent?.setAttribute("data-task", status);
 
         let flatted: STask[] = [item];


### PR DESCRIPTION
This is based on (includes) PR #1047 (which fixes task rendering), and is an incremental change to use the Task Collector modal when completing an item.

This is a suggestion / example of what could work very simply. 

https://user-images.githubusercontent.com/808713/165385825-47f63881-78b5-4ec1-9c54-1b3db73d84b0.mov

