### PR TITLE
fix: fix dataview inline fields render breaks icon shortcodes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "importHelpers": true,
     "downlevelIteration": true,
     "esModuleInterop": true,
-    "lib": ["dom", "es5", "scripthost", "es2018"]
+    "lib": ["dom", "es5", "scripthost", "es2018", "DOM.Iterable"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["lib/**/*"]


### PR DESCRIPTION
replace find-and-replace in innerHTML with TreeWalker and text node manipulation

see also: https://github.com/blacksmithgu/obsidian-dataview/issues/974#issuecomment-1128295242

fix #974