### PR TITLE
Minor Visual Improvements to the Table- and Task count

### DIFF
--- a/src/ui/views/table-view.tsx
+++ b/src/ui/views/table-view.tsx
@@ -36,7 +36,7 @@ export function TableGrouping({
                         {headings.map((heading, index) => (
                             <th class="table-view-th">
                                 <Markdown sourcePath={sourcePath} content={heading} />
-                                {index == 0 && <span class="dataview small-text">&nbsp;({values.length})</span>}
+                                {index == 0 && <span class="dataview small-text">{values.length}</span>}
                             </th>
                         ))}
                     </tr>

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -117,7 +117,7 @@ function TaskGrouping({ items, sourcePath }: { items: Grouping<SListItem>; sourc
                     <Fragment>
                         <h4>
                             <Lit value={item.key} sourcePath={sourcePath} />
-                            <span class="dataview small-text">&nbsp;({Groupings.count(item.rows)})</span>
+                            <span class="dataview small-text">{Groupings.count(item.rows)}</span>
                         </h4>
                         <div class="dataview result-group">
                             <TaskGrouping items={item.rows} sourcePath={sourcePath} />

--- a/styles.css
+++ b/styles.css
@@ -126,5 +126,5 @@ div.dataview-error-box {
 
 .dataview.small-text {
     font-size: smaller;
-    color: var(--text-selection);
+    color: var(--text-muted);
 }

--- a/styles.css
+++ b/styles.css
@@ -127,4 +127,13 @@ div.dataview-error-box {
 .dataview.small-text {
     font-size: smaller;
     color: var(--text-muted);
+    margin-left: 3px;
+}
+
+.dataview.small-text::before {
+	content: "(";
+}
+
+.dataview.small-text::after {
+	content: ")";
 }


### PR DESCRIPTION
- changed the color to one that is more readable by default (`--text-selection` is mostly a very faint color in most themes, since it's used for, well, selections)
- removed the brackets ts code, and instead implemented them via CSS pseudo-elements. This has the advantage that theme developers are able to style the look of the count (e.g. remove the brackets and instead put the number in a circle)