### PR TITLE
feat: LP inline query support

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "typescript": "^4.4.2"
   },
   "dependencies": {
+    "@codemirror/language": "^6.0.0",
+    "@codemirror/state": "^6.0.1",
+    "@codemirror/view": "^6.0.1",
     "emoji-regex": "^10.0.0",
     "localforage": "^1.10.0",
     "luxon": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@zerollup/ts-transform-paths": "^1.7.18",
     "compare-versions": "^4.1.1",
     "jest": "^27.1.0",
-    "obsidian": "^0.14.8",
+    "obsidian": "^0.15.4",
     "prettier": "2.3.2",
     "rollup": "^2.67.2",
     "rollup-jest": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@zerollup/ts-transform-paths": "^1.7.18",
     "compare-versions": "^4.1.1",
     "jest": "^27.1.0",
-    "obsidian": "^0.15.4",
+    "obsidian": "^0.14.8",
     "prettier": "2.3.2",
     "rollup": "^2.67.2",
     "rollup-jest": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.4.2"
   },
   "dependencies": {
-    "@codemirror/language": "^6.0.0",
+    "@codemirror/language": "https://github.com/lishid/cm-language",
     "@codemirror/state": "^6.0.1",
     "@codemirror/view": "^6.0.1",
     "emoji-regex": "^10.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import typescript2 from "rollup-plugin-typescript2";
 
 const BASE_CONFIG = {
     input: "src/main.ts",
-    external: ["obsidian"],
+    external: ["obsidian", "@codemirror/view", "@codemirror/state", "@codemirror/language"],
     onwarn: (warning, warn) => {
         // Sorry rollup, but we're using eval...
         if (/Use of eval is strongly discouraged/.test(warning.message)) return;

--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -161,6 +161,7 @@ export class DataviewApi {
     private _addDataArrays(pageObject: SMarkdownPage): SMarkdownPage {
         // Remap the "file" metadata entries to be data arrays.
         for (let [key, value] of Object.entries(pageObject.file)) {
+            //@ts-ignore; error appeared after updating Obsidian to 0.15.4; it also updated other packages but didn't say which
             if (Array.isArray(value)) (pageObject.file as any)[key] = DataArray.wrap(value, this.settings);
         }
 

--- a/src/data-model/value.ts
+++ b/src/data-model/value.ts
@@ -495,6 +495,7 @@ export class Link {
     }
 
     /** Update this link with a new path. */
+    //@ts-ignore; error appeared after updating Obsidian to 0.15.4; it also updated other packages but didn't say which
     public withPath(path: string) {
         return new Link(Object.assign({}, this, { path }));
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@ import { DateTime } from "luxon";
 import { DataviewInlineApi } from "api/inline-api";
 import { replaceInlineFields } from "ui/views/inline-field";
 import { DataviewInit } from "ui/markdown";
-import {inlinePlugin} from "./ui/lp-render";
-import {Extension} from "@codemirror/state";
+import { inlinePlugin } from "./ui/lp-render";
+import { Extension } from "@codemirror/state";
 
 export default class DataviewPlugin extends Plugin {
     /** Plugin-wide default settigns. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ import { DateTime } from "luxon";
 import { DataviewInlineApi } from "api/inline-api";
 import { replaceInlineFields } from "ui/views/inline-field";
 import { DataviewInit } from "ui/markdown";
+import {inlinePlugin} from "./ui/lp-render";
+import {Extension} from "@codemirror/state";
 
 export default class DataviewPlugin extends Plugin {
     /** Plugin-wide default settigns. */
@@ -21,6 +23,7 @@ export default class DataviewPlugin extends Plugin {
     public index: FullIndex;
     /** External-facing plugin API. */
     public api: DataviewApi;
+    private cmExtension: Extension[];
 
     async onload() {
         // Settings initialization; write defaults first time around.
@@ -74,6 +77,10 @@ export default class DataviewPlugin extends Plugin {
                 await replaceInlineFields(ctx, init);
             }
         });
+
+        // editor extension for inline queries
+        this.cmExtension = [inlinePlugin(this.index, this.settings, this.api)];
+        this.registerEditorExtension(this.cmExtension);
 
         // Dataview "force refresh" operation.
         this.addCommand({

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -128,6 +128,8 @@ function getCssClasses(nodeName: string): string[] {
 }
 
 function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSettings, api: DataviewApi) {
+    // still doesn't work as expected for tables and callouts
+    if (!index.initialized) return;
     const currentFile = app.workspace.getActiveFile();
     if (!currentFile) return;
 
@@ -147,8 +149,6 @@ function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSe
             from,
             to,
             enter: ({ node }) => {
-                // settings and index aren't initialised yet
-                if (!dvSettings || !index) return;
                 const type = node.type;
                 // markdown formatting symbols
                 if (type.name.includes("formatting")) return;

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -57,8 +57,7 @@ function selectionAndRangeOverlap(selection: EditorSelection, rangeFrom:
 
 class InlineWidget extends WidgetType {
 
-    constructor(readonly settings: DataviewSettings,
-                readonly cssClasses: string[], readonly rawQuery: string,
+    constructor(readonly cssClasses: string[], readonly rawQuery: string,
                 private el: HTMLElement) {
         super();
     }
@@ -127,7 +126,7 @@ function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSe
             const type = node.type;
             // markdown formatting symbols
             if (type.name.includes("formatting")) return;
-            if (!regex.test(type.name)) {return}
+            if (!regex.test(type.name)) return;
 
             // at this point bounds contains the position we want to replace and
             // result contains the text with which we want to replace it
@@ -199,7 +198,7 @@ function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSe
 
             widgets.push(
                 Decoration.replace({
-                    widget: new InlineWidget(dvSettings, classes, code, el),
+                    widget: new InlineWidget(classes, code, el),
                     inclusive: false,
                     block: false,
                 }).range(start-1, end+1)

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -144,6 +144,7 @@ function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSe
      *     strikethrough for strikethrough
      */
     const regex = new RegExp(".*?_?inline-code_?.*");
+    const PREAMBLE: string = "const dataview=this;const dv=this;";
 
     for (const { from, to } of view.visibleRanges) {
         syntaxTree(view.state).iterate({
@@ -165,7 +166,6 @@ function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSe
 
                 const text = view.state.doc.sliceString(start, end);
                 let code: string = "";
-                const PREAMBLE: string = "const dataview=this;const dv=this;";
                 let result: Literal = "";
                 const el = createSpan({
                     cls: ["dataview", "dataview-inline"],

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -91,9 +91,10 @@ class InlineWidget extends WidgetType {
      * If the widgets should always be expandable, make this always return false.
      */
     ignoreEvent(event: MouseEvent | Event): boolean {
-        if (event instanceof MouseEvent) {
-            const currentPos = this.view.posAtCoords({ x: event.x, y: event.y });
-            if (event.shiftKey) {
+        // instanceof check does not work in pop-out windows, so check it like this
+        if (event.type === 'mousedown') {
+            const currentPos = this.view.posAtCoords({ x: (event as MouseEvent).x, y: (event as MouseEvent).y });
+            if ((event as MouseEvent).shiftKey) {
                 // Set the cursor after the element so that it doesn't select starting from the last cursor position.
                 if (currentPos) {
                     //@ts-ignore

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -82,8 +82,14 @@ class InlineWidget extends WidgetType {
         return this.el;
     }
 
-    ignoreEvent(event: Event): boolean {
-        return false;
+    ignoreEvent(event: MouseEvent): boolean {
+        // make queries only editable when shift is pressed or navigated inside with the keyboard
+        // or the mouse is placed at the end - mostly useful for links, and makes results selectable
+        // if the queries should always be expandable, always return false
+        if (event.shiftKey) {
+            return false;
+        }
+        return true;
     }
 }
 

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -1,0 +1,218 @@
+/*
+* inspired and adapted from https://github.com/artisticat1/obsidian-latex-suite/blob/main/src/conceal.ts
+*
+* The original work is MIT-licensed.
+*
+* MIT License
+*
+* Copyright (c) 2022 artisticat1
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* */
+
+
+import {EditorView, ViewUpdate, Decoration, ViewPlugin, DecorationSet, WidgetType} from "@codemirror/view";
+import { EditorSelection, Range } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+import {DataviewSettings} from "../settings";
+import { FullIndex } from "../data-index";
+import {/*Component,*/ editorLivePreviewField } from "obsidian";
+//import {asyncEvalInContext, DataviewInlineApi} from "../api/inline-api";
+import {DataviewApi} from "../api/plugin-api";
+import {tryOrPropogate} from "../util/normalize";
+import {parseField} from "../expression/parse";
+import {executeInline} from "../query/engine";
+
+function selectionAndRangeOverlap(selection: EditorSelection, rangeFrom:
+    number, rangeTo: number) {
+
+    for (const range of selection.ranges) {
+        if ((range.from <= rangeTo) && (range.to) >= rangeFrom) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+// also returns text between inline code, so there always needs to be a check whether the correct prefix is used.
+function getInlineCodeBounds(view: EditorView, pos?: number): {start: number, end: number} | null {
+    const text = view.state.doc.toString()
+    if (typeof pos === "undefined") {
+        pos = view.state.selection.main.from;
+    }
+    let left = text.lastIndexOf('`', pos)
+    const right = text.indexOf('`', pos)
+    // no backtick before or after the current backtick
+    if (left === -1 || right === -1) return null;
+    const leftNewline = text.lastIndexOf('\n', pos)
+    const rightNewline = text.indexOf('\n', pos)
+
+    // start or end of document w/o new lines
+    if (leftNewline === -1 || rightNewline === -1) {
+        return {start: left , end: right+1}
+    }
+
+    if (leftNewline > left || rightNewline < right) return null;
+
+    return {start: left , end: right+1}
+}
+
+
+
+
+class InlineWidget extends WidgetType {
+    constructor(readonly markdown: string) {
+        super();
+    }
+    eq(other: InlineWidget): boolean {
+        return other.markdown === this.markdown;
+    }
+
+    toDOM(view: EditorView): HTMLElement {
+        const el = createSpan({
+            text: this.markdown
+        })
+        return el;
+    }
+
+    ignoreEvent(event: Event): boolean {
+        return false;
+    }
+}
+
+
+function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSettings, api: DataviewApi) {
+
+    const widgets: Range<Decoration>[] = []
+    const selection = view.state.selection;
+
+    //@ts-ignore
+    for (const { from, to } of view.visibleRanges) {
+
+        syntaxTree(view.state).iterate({ from, to, enter: ({node}) => {
+            // settings and index aren't initialised yet
+            if (!dvSettings || !index) return;
+            const type = node.type;
+            //const from = node.from;
+            const to = node.to;
+            if (type.name !== "formatting_formatting-code_inline-code") {return}
+            const bounds = getInlineCodeBounds(view, to);
+            if (!bounds) return;
+            const text = view.state.doc.sliceString(bounds.start + 1, bounds.end -1);
+            let code: string;
+            // the `this` isn't correct here, it's just for testing
+            const PREAMBLE: string = "const dataview = comp;const dv=comp;";
+            let result: string = "";
+            const currentFile = app.workspace.getActiveFile();
+            if (!currentFile) return;
+            if (dvSettings.inlineQueryPrefix.length > 0 && text.startsWith(dvSettings.inlineQueryPrefix)) {
+                code = text.substring(dvSettings.inlineQueryPrefix.length).trim()
+                const field = tryOrPropogate(() => parseField(code))
+                if (!field.successful) {
+                    result = `Dataview (inline field '${code}'): ${field.error}`;
+                } else {
+                    const fieldValue = field.value;
+                    const intermediateResult = tryOrPropogate(() => executeInline(fieldValue, currentFile.path, index, dvSettings));
+                    if (!intermediateResult.successful) {
+                        result = `Dataview (for inline query '${fieldValue}'): ${intermediateResult.error}`;
+                    } else {
+                        if (intermediateResult.value) {
+                            result = intermediateResult.value.toString();
+                        }
+                    }
+                }
+            } else if (dvSettings.inlineJsQueryPrefix.length > 0 && text.startsWith(dvSettings.inlineJsQueryPrefix)) {
+                if (dvSettings.enableInlineDataviewJs) {
+                    code = text.substring(dvSettings.inlineJsQueryPrefix.length).trim()
+                    try {
+                        // how do I set the `this` context properly?
+                        const comp = {
+                            api: api,
+                            current: () => currentFile,
+                            settings: dvSettings,
+                            index: index
+                        }
+                        if (code.includes("await")) {
+                            // await doesn't seem to work with it because the WidgetPlugin expects it to be synchronous
+                            (evalWoContext("(async () => { " + PREAMBLE + code + " })()") as Promise<any>).then((value: any) => result = value)
+                        } else {
+                            result = evalWoContext(PREAMBLE + code);
+                        }
+
+                        function evalWoContext(script: string): any {
+                            return function () {return eval(script)}.call(comp);
+                        }
+                    } catch (e) {
+                        result = `Dataview (for inline JS query '${code}'): ${e}`;
+                    }
+                } else {
+                    result = "(disabled; enable in settings)";
+                }
+
+            } else {
+                return;
+            }
+
+            // at this point bounds contains the position we want to replace and
+            // result contains the text with which we want to replace it
+            const start = bounds.start;
+            const end = bounds.end;
+            if (selectionAndRangeOverlap(selection, start, end)) return;
+
+            widgets.push(
+                Decoration.replace({
+                    // @ts-ignore
+                    widget: new InlineWidget(result, currentFile.path, index, dvSettings),
+                    inclusive: false,
+                    block: false,
+                }).range(start, end)
+            );
+
+            }
+
+        });
+    }
+
+    return Decoration.set(widgets, true)
+}
+
+
+
+export function inlinePlugin(index: FullIndex, settings: DataviewSettings, api: DataviewApi) {
+    return ViewPlugin.fromClass(class {
+        decorations: DecorationSet
+
+        constructor(view: EditorView) {
+            this.decorations = inlineRender(view, index, settings, api)
+        }
+
+        update(update: ViewUpdate) {
+            //@ts-ignore
+            if (!update.state.field(editorLivePreviewField)) {
+                this.decorations = Decoration.none;
+                return;
+            }
+            if (update.docChanged || update.viewportChanged || update.selectionSet)
+                this.decorations = inlineRender(update.view, index, settings, api)
+        }
+    }, {decorations: v => v.decorations,});
+}

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -89,9 +89,11 @@ class InlineWidget extends WidgetType {
      * or the mouse is placed at the end, but that is always possible regardless of this method).
      * Mostly useful for links, and makes results selectable.
      * If the widgets should always be expandable, make this always return false.
+     * @param event - Is either of type MouseEvent or Event; set to UIEvent so that the type check for pop-out windows works.
+     * https://github.com/obsidianmd/obsidian-api/blob/b9bde9e32c007eb28c0fd632cf2c42b01dfd022a/obsidian.d.ts#L50-L53
      */
-    ignoreEvent(event: MouseEvent | Event): boolean {
-        if (event instanceof MouseEvent) {
+    ignoreEvent(event: UIEvent): boolean {
+        if (event.instanceOf(MouseEvent)) {
             const currentPos = this.view.posAtCoords({ x: event.x, y: event.y });
             if (event.shiftKey) {
                 // Set the cursor after the element so that it doesn't select starting from the last cursor position.

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -228,8 +228,9 @@ export function inlinePlugin(index: FullIndex, settings: DataviewSettings, api: 
                 this.decorations = Decoration.none;
                 return;
             }
-            if (update.docChanged || update.viewportChanged || update.selectionSet)
+            if (update.docChanged || update.viewportChanged || update.selectionSet) {
                 this.decorations = inlineRender(update.view, index, settings, api)
+            }
         }
     }, {decorations: v => v.decorations,});
 }

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -1,52 +1,49 @@
 /*
-* inspired and adapted from https://github.com/artisticat1/obsidian-latex-suite/blob/main/src/conceal.ts
-*
-* The original work is MIT-licensed.
-*
-* MIT License
-*
-* Copyright (c) 2022 artisticat1
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*
-* */
+ * inspired and adapted from https://github.com/artisticat1/obsidian-latex-suite/blob/main/src/conceal.ts
+ *
+ * The original work is MIT-licensed.
+ *
+ * MIT License
+ *
+ * Copyright (c) 2022 artisticat1
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * */
 
+import { Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate, WidgetType } from "@codemirror/view";
+import { EditorSelection, Range } from "@codemirror/state";
+import { syntaxTree } from "@codemirror/language";
+import { DataviewSettings } from "../settings";
+import { FullIndex } from "../data-index";
+import { Component, editorEditorField, editorLivePreviewField, editorViewField } from "obsidian";
+import { DataviewApi } from "../api/plugin-api";
+import { tryOrPropogate } from "../util/normalize";
+import { parseField } from "../expression/parse";
+import { executeInline } from "../query/engine";
+import { Literal } from "../data-model/value";
+import { DataviewInlineApi } from "../api/inline-api";
+import { renderValue } from "./render";
 
-import {Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate, WidgetType} from "@codemirror/view";
-import {EditorSelection, Range} from "@codemirror/state";
-import {syntaxTree} from "@codemirror/language";
-import {DataviewSettings} from "../settings";
-import {FullIndex} from "../data-index";
-import {Component, editorEditorField, editorLivePreviewField, editorViewField} from "obsidian";
-import {DataviewApi} from "../api/plugin-api";
-import {tryOrPropogate} from "../util/normalize";
-import {parseField} from "../expression/parse";
-import {executeInline} from "../query/engine";
-import {Literal} from "../data-model/value";
-import {DataviewInlineApi} from "../api/inline-api";
-import {renderValue} from "./render";
-
-function selectionAndRangeOverlap(selection: EditorSelection, rangeFrom:
-    number, rangeTo: number) {
-
+function selectionAndRangeOverlap(selection: EditorSelection, rangeFrom: number, rangeTo: number) {
     for (const range of selection.ranges) {
-        if ((range.from <= rangeTo) && (range.to) >= rangeFrom) {
+        if (range.from <= rangeTo && range.to >= rangeFrom) {
             return true;
         }
     }
@@ -54,11 +51,13 @@ function selectionAndRangeOverlap(selection: EditorSelection, rangeFrom:
     return false;
 }
 
-
 class InlineWidget extends WidgetType {
-
-    constructor(readonly cssClasses: string[], readonly rawQuery: string,
-                private el: HTMLElement, private view: EditorView) {
+    constructor(
+        readonly cssClasses: string[],
+        readonly rawQuery: string,
+        private el: HTMLElement,
+        private view: EditorView
+    ) {
         super();
     }
 
@@ -93,12 +92,12 @@ class InlineWidget extends WidgetType {
      */
     ignoreEvent(event: MouseEvent | Event): boolean {
         if (event instanceof MouseEvent) {
-            const currentPos = this.view.posAtCoords({x: event.x, y: event.y})
+            const currentPos = this.view.posAtCoords({ x: event.x, y: event.y });
             if (event.shiftKey) {
                 // Set the cursor after the element so that it doesn't select starting from the last cursor position.
                 if (currentPos) {
                     //@ts-ignore
-                    const {editor} = this.view.state.field(editorEditorField).state.field(editorViewField);
+                    const { editor } = this.view.state.field(editorEditorField).state.field(editorViewField);
                     editor.setCursor(editor.offsetToPos(currentPos));
                 }
                 return false;
@@ -108,26 +107,27 @@ class InlineWidget extends WidgetType {
     }
 }
 
-
 function getCssClasses(nodeName: string): string[] {
     const classes: string[] = [];
     if (nodeName.includes("strong")) {
         classes.push("cm-strong");
-    } if (nodeName.includes("em")) {
+    }
+    if (nodeName.includes("em")) {
         classes.push("cm-em");
-    } if (nodeName.includes("highlight")) {
+    }
+    if (nodeName.includes("highlight")) {
         classes.push("cm-highlight");
-    } if (nodeName.includes("strikethrough")) {
+    }
+    if (nodeName.includes("strikethrough")) {
         classes.push("cm-strikethrough");
-    } if (nodeName.includes("comment")) {
+    }
+    if (nodeName.includes("comment")) {
         classes.push("cm-comment");
     }
     return classes;
 }
 
-
 function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSettings, api: DataviewApi) {
-
     const currentFile = app.workspace.getActiveFile();
     if (!currentFile) return;
 
@@ -143,122 +143,143 @@ function inlineRender(view: EditorView, index: FullIndex, dvSettings: DataviewSe
     const regex = new RegExp(".*?_?inline-code_?.*");
 
     for (const { from, to } of view.visibleRanges) {
+        syntaxTree(view.state).iterate({
+            from,
+            to,
+            enter: ({ node }) => {
+                // settings and index aren't initialised yet
+                if (!dvSettings || !index) return;
+                const type = node.type;
+                // markdown formatting symbols
+                if (type.name.includes("formatting")) return;
+                // current node is not inline code
+                if (!regex.test(type.name)) return;
 
-        syntaxTree(view.state).iterate({ from, to, enter: ({node}) => {
-            // settings and index aren't initialised yet
-            if (!dvSettings || !index) return;
-            const type = node.type;
-            // markdown formatting symbols
-            if (type.name.includes("formatting")) return;
-            // current node is not inline code
-            if (!regex.test(type.name)) return;
+                // contains the position of inline code
+                const start = node.from;
+                const end = node.to;
+                // don't continue if current cursor position and inline code node (including formatting
+                // symbols) overlap
+                if (selectionAndRangeOverlap(selection, start - 1, end + 1)) return;
 
-            // contains the position of inline code
-            const start = node.from;
-            const end = node.to;
-            // don't continue if current cursor position and inline code node (including formatting
-            // symbols) overlap
-            if (selectionAndRangeOverlap(selection, start-1, end+1)) return;
-
-            const text = view.state.doc.sliceString(start, end);
-            let code: string = "";
-            const PREAMBLE: string = "const dataview=this;const dv=this;";
-            let result: Literal = "";
-            const el = createSpan({
-                cls: ['dataview', 'dataview-inline']
-            });
-            /* If the query result is predefined text (e.g. in the case of errors), set innerText to it.
-             * Otherwise, pass on an empty element and fill it in later.
-             * This is necessary because {@link InlineWidget.toDOM} is synchronous but some rendering
-             * asynchronous.
-             */
-            if (dvSettings.inlineQueryPrefix.length > 0 && text.startsWith(dvSettings.inlineQueryPrefix)) {
-                code = text.substring(dvSettings.inlineQueryPrefix.length).trim()
-                const field = tryOrPropogate(() => parseField(code));
-                if (!field.successful) {
-                    result = `Dataview (inline field '${code}'): ${field.error}`;
-                    el.innerText = result;
-                } else {
-                    const fieldValue = field.value;
-                    const intermediateResult = tryOrPropogate(() => executeInline(fieldValue, currentFile.path, index, dvSettings));
-                    if (!intermediateResult.successful) {
-                        result = `Dataview (for inline query '${fieldValue}'): ${intermediateResult.error}`;
+                const text = view.state.doc.sliceString(start, end);
+                let code: string = "";
+                const PREAMBLE: string = "const dataview=this;const dv=this;";
+                let result: Literal = "";
+                const el = createSpan({
+                    cls: ["dataview", "dataview-inline"],
+                });
+                /* If the query result is predefined text (e.g. in the case of errors), set innerText to it.
+                 * Otherwise, pass on an empty element and fill it in later.
+                 * This is necessary because {@link InlineWidget.toDOM} is synchronous but some rendering
+                 * asynchronous.
+                 */
+                if (dvSettings.inlineQueryPrefix.length > 0 && text.startsWith(dvSettings.inlineQueryPrefix)) {
+                    code = text.substring(dvSettings.inlineQueryPrefix.length).trim();
+                    const field = tryOrPropogate(() => parseField(code));
+                    if (!field.successful) {
+                        result = `Dataview (inline field '${code}'): ${field.error}`;
                         el.innerText = result;
                     } else {
-                        const { value } = intermediateResult;
-                        result = value;
-                        renderValue(result, el, currentFile.path, null as unknown as Component, dvSettings)
-                    }
-                }
-            } else if (dvSettings.inlineJsQueryPrefix.length > 0 && text.startsWith(dvSettings.inlineJsQueryPrefix)) {
-                if (dvSettings.enableInlineDataviewJs) {
-                    code = text.substring(dvSettings.inlineJsQueryPrefix.length).trim()
-                    try {
-                        // for setting the correct context for dv/dataview
-                        const myEl = createDiv();
-                        const dvInlineApi = new DataviewInlineApi(api, null as unknown as Component, myEl, currentFile.path);
-                        if (code.includes("await")) {
-                            (evalInContext("(async () => { " + PREAMBLE + code + " })()") as Promise<any>).then((result: any) => {
-                                renderValue(result, el, currentFile.path, null as unknown as Component, dvSettings)
-                            })
+                        const fieldValue = field.value;
+                        const intermediateResult = tryOrPropogate(() =>
+                            executeInline(fieldValue, currentFile.path, index, dvSettings)
+                        );
+                        if (!intermediateResult.successful) {
+                            result = `Dataview (for inline query '${fieldValue}'): ${intermediateResult.error}`;
+                            el.innerText = result;
                         } else {
-                            result = evalInContext(PREAMBLE + code);
-                            renderValue(result, el, currentFile.path, null as unknown as Component, dvSettings)
+                            const { value } = intermediateResult;
+                            result = value;
+                            renderValue(result, el, currentFile.path, null as unknown as Component, dvSettings);
                         }
+                    }
+                } else if (
+                    dvSettings.inlineJsQueryPrefix.length > 0 &&
+                    text.startsWith(dvSettings.inlineJsQueryPrefix)
+                ) {
+                    if (dvSettings.enableInlineDataviewJs) {
+                        code = text.substring(dvSettings.inlineJsQueryPrefix.length).trim();
+                        try {
+                            // for setting the correct context for dv/dataview
+                            const myEl = createDiv();
+                            const dvInlineApi = new DataviewInlineApi(
+                                api,
+                                null as unknown as Component,
+                                myEl,
+                                currentFile.path
+                            );
+                            if (code.includes("await")) {
+                                (evalInContext("(async () => { " + PREAMBLE + code + " })()") as Promise<any>).then(
+                                    (result: any) => {
+                                        renderValue(
+                                            result,
+                                            el,
+                                            currentFile.path,
+                                            null as unknown as Component,
+                                            dvSettings
+                                        );
+                                    }
+                                );
+                            } else {
+                                result = evalInContext(PREAMBLE + code);
+                                renderValue(result, el, currentFile.path, null as unknown as Component, dvSettings);
+                            }
 
-                        function evalInContext(script: string): any {
-                            return function () {return eval(script)}.call(dvInlineApi);
+                            function evalInContext(script: string): any {
+                                return function () {
+                                    return eval(script);
+                                }.call(dvInlineApi);
+                            }
+                        } catch (e) {
+                            result = `Dataview (for inline JS query '${code}'): ${e}`;
+                            el.innerText = result;
                         }
-                    } catch (e) {
-                        result = `Dataview (for inline JS query '${code}'): ${e}`;
+                    } else {
+                        result = "(disabled; enable in settings)";
                         el.innerText = result;
                     }
                 } else {
-                    result = "(disabled; enable in settings)";
-                    el.innerText = result;
+                    return;
                 }
 
-            } else {
-                return;
-            }
+                const classes = getCssClasses(type.name);
 
-            const classes = getCssClasses(type.name);
-
-            widgets.push(
-                Decoration.replace({
-                    widget: new InlineWidget(classes, code, el, view),
-                    inclusive: false,
-                    block: false,
-                }).range(start-1, end+1)
-            );
-
-            }
-
+                widgets.push(
+                    Decoration.replace({
+                        widget: new InlineWidget(classes, code, el, view),
+                        inclusive: false,
+                        block: false,
+                    }).range(start - 1, end + 1)
+                );
+            },
         });
     }
 
-    return Decoration.set(widgets, true)
+    return Decoration.set(widgets, true);
 }
 
-
 export function inlinePlugin(index: FullIndex, settings: DataviewSettings, api: DataviewApi) {
-    return ViewPlugin.fromClass(class {
-        decorations: DecorationSet
+    return ViewPlugin.fromClass(
+        class {
+            decorations: DecorationSet;
 
-        constructor(view: EditorView) {
-            this.decorations = inlineRender(view, index, settings, api) ?? Decoration.none;
-        }
+            constructor(view: EditorView) {
+                this.decorations = inlineRender(view, index, settings, api) ?? Decoration.none;
+            }
 
-        update(update: ViewUpdate) {
-            // only activate in LP and not source mode
-            //@ts-ignore
-            if (!update.state.field(editorLivePreviewField)) {
-                this.decorations = Decoration.none;
-                return;
+            update(update: ViewUpdate) {
+                // only activate in LP and not source mode
+                //@ts-ignore
+                if (!update.state.field(editorLivePreviewField)) {
+                    this.decorations = Decoration.none;
+                    return;
+                }
+                if (update.docChanged || update.viewportChanged || update.selectionSet) {
+                    this.decorations = inlineRender(update.view, index, settings, api) ?? Decoration.none;
+                }
             }
-            if (update.docChanged || update.viewportChanged || update.selectionSet) {
-                this.decorations = inlineRender(update.view, index, settings, api) ?? Decoration.none;
-            }
-        }
-    }, {decorations: v => v.decorations,});
+        },
+        { decorations: v => v.decorations }
+    );
 }

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -89,11 +89,9 @@ class InlineWidget extends WidgetType {
      * or the mouse is placed at the end, but that is always possible regardless of this method).
      * Mostly useful for links, and makes results selectable.
      * If the widgets should always be expandable, make this always return false.
-     * @param event - Is either of type MouseEvent or Event; set to UIEvent so that the type check for pop-out windows works.
-     * https://github.com/obsidianmd/obsidian-api/blob/b9bde9e32c007eb28c0fd632cf2c42b01dfd022a/obsidian.d.ts#L50-L53
      */
-    ignoreEvent(event: UIEvent): boolean {
-        if (event.instanceOf(MouseEvent)) {
+    ignoreEvent(event: MouseEvent | Event): boolean {
+        if (event instanceof MouseEvent) {
             const currentPos = this.view.posAtCoords({ x: event.x, y: event.y });
             if (event.shiftKey) {
                 // Set the cursor after the element so that it doesn't select starting from the last cursor position.


### PR DESCRIPTION
There are still issues with it.

The widgets for normal queries work, but they display the output differently.
Edit: because I didn't make use of this (second commit implements pretty rendering for dates, durations and functions):
https://github.com/blacksmithgu/obsidian-dataview/blob/8383d1ab06e149c654fe71a883e1a3618c0c681b/src/ui/render.ts#L45
I think for LP I'd need a synchronous implementation, unless you find a way to make it work asynchronously. 

LP:

![screenshot](https://user-images.githubusercontent.com/83140328/178006315-339fc885-7803-4b7e-958e-5d35f77aa254.png)

Reading mode:

![screenshot](https://user-images.githubusercontent.com/83140328/178006513-6a76cfe3-4387-4ce6-874e-8b1293ec6bcb.png)

**JS queries don't work correctly, because I don't know how to set the context properly. (for `dv/dataview.`)** I mocked one for testing. See the comments for that. Async js doesn't work because the Widget expects synchronous code.

I don't know enough about dataview's internals for that. If you could fix the remaining issues, this would close #729.