### PR TITLE
Filter out nested intersecting inline fields

### DIFF
--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -138,7 +138,14 @@ export function extractInlineFields(line: string, includeTaskFields: boolean = f
     if (includeTaskFields) fields = fields.concat(extractSpecialTaskFields(line));
 
     fields.sort((a, b) => a.start - b.start);
-    return fields;
+    
+    let filteredFields: InlineField[] = [];
+    for (let i = 0; i < fields.length; i++) {
+        if (i == 0 || filteredFields[filteredFields.length-1].end < fields[i].start) {
+            filteredFields.push(fields[i]);
+        }
+    }
+    return filteredFields;
 }
 
 /** Validates that a raw field name has a valid form. */


### PR DESCRIPTION
It is possible to nest fields in other fields however the current code renders them incorrectly.
This is due to the code finding and processing the outer and inner fields at once.
This modification removes any fields that intersect an outer field allowing them to be processed correctly.

I am fairly new to javascript so there may be a better way to implement this.

### Source
```md
[a:: 0]
(a:: 0)
[a:: [b:: 0]]
[a:: (b:: 0)]
(a:: [b:: 0])
(a:: (b:: 0))
[a:: [b:: [c:: 0]]]
[a:: [b:: (c:: 0)]]
[a:: (b:: [c:: 0])]
[a:: (b:: (c:: 0))]
(a:: [b:: [c:: 0]])
(a:: [b:: (c:: 0)])
(a:: (b:: [c:: 0]))
(a:: (b:: (c:: 0)))
```

### Before modification
![image](https://user-images.githubusercontent.com/11940194/180409708-46f1a8f3-433d-460c-bec2-c2441c7e86d9.png)

### After modification
![image](https://user-images.githubusercontent.com/11940194/180409502-69de1239-19fe-412c-882f-4902cfbf8fbb.png)
