### PR TITLE
feat: tasks emoji shorthands `start` & `scheduled`

### DIFF
--- a/docs/docs/data-annotation.md
+++ b/docs/docs/data-annotation.md
@@ -124,7 +124,7 @@ with:
 Note that, if you do not like emojis, you can still annotate these fields textually (`[due:: ]`, `[created:: ]`,
 `[completion:: ]`, `[start:: ]`, `[scheduled:: ]`).
 
-### Task Implicit Fields
+### Implicit Fields
 
 As with pages, Dataview adds a number of implicit fields to each task:
 

--- a/docs/docs/data-annotation.md
+++ b/docs/docs/data-annotation.md
@@ -59,7 +59,7 @@ reviewed: false
 [mood:: okay] | [length:: 2 hours]
 ```
 
-#### Implicit Fields
+### Implicit Fields
 
 Dataview automatically adds a large amount of metadata to each page:
 
@@ -103,7 +103,7 @@ You can also annotate your *tasks* (I.e., lines of the form `- [ ] blah blah bla
 - [X] I finished this on [completion::2021-08-15].
 ```
 
-#### Field Shorthands
+### Field Shorthands
 
 For supporting "common use cases", Dataview understands a few shorthands for common data you may want to annotate task
 with:
@@ -112,15 +112,19 @@ with:
     - Due Date: `🗓️YYYY-MM-DD`
     - Completed Date: `✅YYYY-MM-DD`
     - Created Date: `➕YYYY-MM-DD`
+    - Start Date: `🛫YYYY-MM-DD`
+    - Scheduled Date: `⏳YYYY-MM-DD`
 === "Example"
     - [ ] Do this saturday 🗓️2021-08-29.
     - [x] Completed last saturday ✅2021-08-22.
     - [ ] I made this on ➕1990-06-14.
+    - [ ] Task I can start this weekend 🛫2021-08-29.
+    - [x] Task I finished ahead of schedule ⏳2021-08-29 ✅2021-08-22.
 
 Note that, if you do not like emojis, you can still annotate these fields textually (`[due:: ]`, `[created:: ]`,
-`[completion:: ]`).
+`[completion:: ]`, `[start:: ]`, `[scheduled:: ]`).
 
-#### Implicit Fields
+### Task Implicit Fields
 
 As with pages, Dataview adds a number of implicit fields to each task:
 
@@ -147,6 +151,8 @@ As with pages, Dataview adds a number of implicit fields to each task:
 - `completion`: The date a task was completed; set by `[completion:: ...]` or shorthand syntax.
 - `due`: The date a task is due, if it has one. Set by `[due:: ...]` or shorthand syntax.
 - `created`: The date a task was created; set by `[created:: ...]` or shorthand syntax.
+- `start`: The date a task can be started; set by `[start:: ...]` or shorthand syntax.
+- `scheduled`: The date a task is scheduled to work on; set by `[scheduled:: ...]` or shorthand syntax.
 - `annotated`: True if the task has any custom annotations, and false otherwise.
 - `parent`: The line number of the task above this task, if present; will be null if this is a root-level task.
 - `blockId`: The block ID of this task / list element, if one has been defined with the `^blockId` syntax; otherwise null.

--- a/docs/docs/data-annotation.md
+++ b/docs/docs/data-annotation.md
@@ -115,11 +115,11 @@ with:
     - Start Date: `🛫YYYY-MM-DD`
     - Scheduled Date: `⏳YYYY-MM-DD`
 === "Example"
-    - [ ] Due this saturday 🗓️2021-08-29.
-    - [x] Completed last saturday ✅2021-08-22.
-    - [ ] I made this on ➕1990-06-14.
-    - [ ] Task I can start this weekend 🛫2021-08-29.
-    - [x] Task I finished ahead of schedule ⏳2021-08-29 ✅2021-08-22.
+    - [ ] Due this saturday 🗓️2021-08-29
+    - [x] Completed last saturday ✅2021-08-22
+    - [ ] I made this on ➕1990-06-14
+    - [ ] Task I can start this weekend 🛫2021-08-29
+    - [x] Task I finished ahead of schedule ⏳2021-08-29 ✅2021-08-22
 
 Note that, if you do not like emojis, you can still annotate these fields textually (`[due:: ]`, `[created:: ]`,
 `[completion:: ]`, `[start:: ]`, `[scheduled:: ]`).
@@ -148,11 +148,11 @@ As with pages, Dataview adds a number of implicit fields to each task:
 - `link`: A link to the closest linkable block near this task; useful for making links which go to the task.
 - `children`: Any subtasks or sublists of this task.
 - `task`: If true, this is a task; otherwise, it is a regular list element.
-- `completion`: The date a task was completed; set by `[completion:: ...]` or shorthand syntax.
-- `due`: The date a task is due, if it has one. Set by `[due:: ...]` or shorthand syntax.
-- `created`: The date a task was created; set by `[created:: ...]` or shorthand syntax.
-- `start`: The date a task can be started; set by `[start:: ...]` or shorthand syntax.
-- `scheduled`: The date a task is scheduled to work on; set by `[scheduled:: ...]` or shorthand syntax.
+- `completion`: The date a task was completed; set by `[completion:: ...]` or [shorthand syntax](#field-shorthands).
+- `due`: The date a task is due, if it has one. Set by `[due:: ...]` or [shorthand syntax](#field-shorthands).
+- `created`: The date a task was created; set by `[created:: ...]` or [shorthand syntax](#field-shorthands).
+- `start`: The date a task can be started; set by `[start:: ...]` or [shorthand syntax](#field-shorthands).
+- `scheduled`: The date a task is scheduled to work on; set by `[scheduled:: ...]` or [shorthand syntax](#field-shorthands).
 - `annotated`: True if the task has any custom annotations, and false otherwise.
 - `parent`: The line number of the task above this task, if present; will be null if this is a root-level task.
 - `blockId`: The block ID of this task / list element, if one has been defined with the `^blockId` syntax; otherwise null.

--- a/docs/docs/data-annotation.md
+++ b/docs/docs/data-annotation.md
@@ -115,7 +115,7 @@ with:
     - Start Date: `🛫YYYY-MM-DD`
     - Scheduled Date: `⏳YYYY-MM-DD`
 === "Example"
-    - [ ] Do this saturday 🗓️2021-08-29.
+    - [ ] Due this saturday 🗓️2021-08-29.
     - [x] Completed last saturday ✅2021-08-22.
     - [ ] I made this on ➕1990-06-14.
     - [ ] Task I can start this weekend 🛫2021-08-29.

--- a/docs/docs/data-annotation.md
+++ b/docs/docs/data-annotation.md
@@ -165,22 +165,22 @@ All fields in dataview have a *type*, which determines how dataview will render,
 Dataview understands several distinct field types to cover common use cases:
 
 - **Text**: The default catch-all. If a field doesn't match a more specific type, it is just plain text.
-    ```
+    ```markdown
     Example:: This is some normal text.
     ```
 - **Number**: Numbers like '6' and '3.6'.
-    ```
+    ```markdown
     Example:: 6
     Example:: 2.4
     Example:: -80
     ```
 - **Boolean**: true/false, as the programming concept.
-    ```
+    ```markdown
     Example:: true
     Example:: false
     ```
 - **Date**: ISO8601 dates of the general form `YYYY-MM[-DDTHH:mm:ss.nnn+ZZ]`. Everything after the month is optional.
-    ```
+    ```markdown
     Example:: 2021-04-18
     Example:: 2021-04-18T04:19:35.000
     Example:: 2021-04-18T04:19:35.000+06:30
@@ -188,7 +188,7 @@ Dataview understands several distinct field types to cover common use cases:
 - **Duration**: Durations of the form `<time> <unit>`, like `6 hours` or `4 minutes`. Common english abbreviations like
   `6hrs` or `2m` are accepted. You can specify multiple units using an optional comma separator: `6 hours, 4 minutes`
   or `6hr4min`.
-    ```
+    ```markdown
     Example:: 7 hours
     Example:: 4min
     Example:: 16 days
@@ -197,19 +197,19 @@ Dataview understands several distinct field types to cover common use cases:
     ```
 - **Link**: Plain Obsidian links like `[[Page]]` or `[[Page|Page Display]]`.
     - If you reference a link in frontmatter, you need to quote it, as so: `key: "[[Link]]"`. This is default Obsidian-supported behavior.
-    ```
+    ```markdown
     Example:: [[A Page]]
     Example:: [[Some Other Page|Render Text]]
     ```
 - **List**: Lists of other dataview fields. In YAML, these are defined as normal YAML lists; for inline fields, they are
   just comma-separated lists.
-    ```
+    ```markdown
     Example:: 1, 2, 3
     Example:: "yes", "or", "no"
     ```
 - **Object**: A map of name to dataview field. These can only be defined in YAML frontmatter, using the normal YAML
   object syntax:
-  ```
+  ```yaml
   field:
     value1: 1
     value2: 2

--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -173,9 +173,9 @@ export function extractFullLineField(text: string): InlineField | undefined {
 }
 
 export const CREATED_DATE_REGEX = /\u{2795}\s*(\d{4}-\d{2}-\d{2})/u;
-export const DUE_DATE_REGEX = /(?:\u{1F4C5}|\u{1F4C6}|\u{1F5D3}|\u{FE0F})\s*(\d{4}-\d{2}-\d{2})/u;
+export const DUE_DATE_REGEX = /[\u{1F4C5}\u{1F4C6}\u{1F5D3}\u{FE0F}]\s*(\d{4}-\d{2}-\d{2})/u;
 export const DONE_DATE_REGEX = /\u{2705}\s*(\d{4}-\d{2}-\d{2})/u;
-export const SCHEDULED_DATE_REGEX = /(?:\u{23F3}|\u{231B})\s*(\d{4}-\d{2}-\d{2})/u;
+export const SCHEDULED_DATE_REGEX = /[\u{23F3}\u{231B}]\s*(\d{4}-\d{2}-\d{2})/u;
 export const START_DATE_REGEX = /\u{1F6EB}\s*(\d{4}-\d{2}-\d{2})/u;
 
 /** Parse special completed/due/done task fields which are marked via emoji. */

--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -173,45 +173,33 @@ export function extractFullLineField(text: string): InlineField | undefined {
 }
 
 export const CREATED_DATE_REGEX = /\u{2795}\s*(\d{4}-\d{2}-\d{2})/u;
-export const DUE_DATE_REGEX = /[\u{1F4C5}\u{1F4C6}\u{1F5D3}\u{FE0F}]{1,}\s*(\d{4}-\d{2}-\d{2})/u;
+export const DUE_DATE_REGEX = /(?:\u{1F4C5}|\u{1F4C6}|\u{1F5D3}|\u{FE0F})\s*(\d{4}-\d{2}-\d{2})/u;
 export const DONE_DATE_REGEX = /\u{2705}\s*(\d{4}-\d{2}-\d{2})/u;
+export const SCHEDULED_DATE_REGEX = /(?:\u{23F3}|\u{231B})\s*(\d{4}-\d{2}-\d{2})/u;
+export const START_DATE_REGEX = /\u{1F6EB}\s*(\d{4}-\d{2}-\d{2})/u;
 
 /** Parse special completed/due/done task fields which are marked via emoji. */
 function extractSpecialTaskFields(line: string): InlineField[] {
-    let results = [];
+    let results: InlineField[] = [];
 
-    let createdMatch = CREATED_DATE_REGEX.exec(line);
-    if (createdMatch)
-        results.push({
-            key: "created",
-            value: createdMatch[1],
-            start: createdMatch.index,
-            startValue: createdMatch.index + 1,
-            end: createdMatch.index + createdMatch[0].length,
-            wrapping: "emoji-shorthand",
-        });
-
-    let dueMatch = DUE_DATE_REGEX.exec(line);
-    if (dueMatch)
-        results.push({
-            key: "due",
-            value: dueMatch[1],
-            start: dueMatch.index,
-            startValue: dueMatch.index + 1,
-            end: dueMatch.index + dueMatch[0].length,
-            wrapping: "emoji-shorthand",
-        });
-
-    let completedMatch = DONE_DATE_REGEX.exec(line);
-    if (completedMatch)
-        results.push({
-            key: "completion",
-            value: completedMatch[1],
-            start: completedMatch.index,
-            startValue: completedMatch.index + 1,
-            end: completedMatch.index + completedMatch[0].length,
-            wrapping: "emoji-shorthand",
-        });
+    [
+        { shorthandDateRegex: CREATED_DATE_REGEX, shorthandDateKey: "created" },
+        { shorthandDateRegex: START_DATE_REGEX, shorthandDateKey: "start" },
+        { shorthandDateRegex: SCHEDULED_DATE_REGEX, shorthandDateKey: "scheduled" },
+        { shorthandDateRegex: DUE_DATE_REGEX, shorthandDateKey: "due" },
+        { shorthandDateRegex: DONE_DATE_REGEX, shorthandDateKey: "completion" },
+    ].forEach(shorthandRegexAndKey => {
+        const shorthandDateMatch = shorthandRegexAndKey.shorthandDateRegex.exec(line);
+        if (shorthandDateMatch)
+            results.push({
+                key: shorthandRegexAndKey.shorthandDateKey,
+                value: shorthandDateMatch[1],
+                start: shorthandDateMatch.index,
+                startValue: shorthandDateMatch.index + 1,
+                end: shorthandDateMatch.index + shorthandDateMatch[0].length,
+                wrapping: "emoji-shorthand",
+            });
+    });
 
     return results;
 }

--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -173,7 +173,7 @@ export function extractFullLineField(text: string): InlineField | undefined {
 }
 
 export const CREATED_DATE_REGEX = /\u{2795}\s*(\d{4}-\d{2}-\d{2})/u;
-export const DUE_DATE_REGEX = /[\u{1F4C5}\u{1F4C6}\u{1F5D3}\u{FE0F}]\s*(\d{4}-\d{2}-\d{2})/u;
+export const DUE_DATE_REGEX = /(?:\u{1F4C5}|\u{1F4C6}|\u{1F5D3}\u{FE0F})\s*(\d{4}-\d{2}-\d{2})/u;
 export const DONE_DATE_REGEX = /\u{2705}\s*(\d{4}-\d{2}-\d{2})/u;
 export const SCHEDULED_DATE_REGEX = /[\u{23F3}\u{231B}]\s*(\d{4}-\d{2}-\d{2})/u;
 export const START_DATE_REGEX = /\u{1F6EB}\s*(\d{4}-\d{2}-\d{2})/u;

--- a/src/data-model/markdown.ts
+++ b/src/data-model/markdown.ts
@@ -237,6 +237,14 @@ export class ListItem {
             this.fields.get("compday"))?.[0];
     }
 
+    public start(): Literal | undefined {
+        return this.fields.get("start")?.[0];
+    }
+
+    public scheduled(): Literal | undefined {
+        return this.fields.get("scheduled")?.[0];
+    }
+
     /** Create an API-friendly copy of this list item. De-duplication is done via the provided cache. */
     public serialize(cache: ListSerializationCache): SListItem {
         // Map children to their serialized/de-duplicated equivalents right away.
@@ -276,11 +284,15 @@ export class ListItem {
 
             let created = this.created(),
                 due = this.due(),
-                completed = this.completed();
+                completed = this.completed(),
+                start = this.start(),
+                scheduled = this.scheduled();
 
             if (created) result.created = Values.deepCopy(created);
             if (due) result.due = Values.deepCopy(due);
             if (completed) result.completion = Values.deepCopy(completed);
+            if (start) result.start = Values.deepCopy(start);
+            if (scheduled) result.scheduled = Values.deepCopy(scheduled);
         }
 
         return result as SListItem;

--- a/src/data-model/serialized/markdown.ts
+++ b/src/data-model/serialized/markdown.ts
@@ -114,4 +114,8 @@ export interface STask extends SListItemBase {
     due?: Literal;
     /** If present, then the time that this task was completed. */
     completion?: Literal;
+    /** If present, then the day that this task can be started. */
+    start?: Literal;
+    /** If present, then the day that work on this task is scheduled. */
+    scheduled?: Literal;
 }

--- a/src/test/parse/parse.inline.test.ts
+++ b/src/test/parse/parse.inline.test.ts
@@ -119,6 +119,26 @@ describe("Inline Inline With HTML", () => {
     });
 });
 
+describe("Inline task emoji shorthands", () => {
+    test("Created emoji shorthand", () => {
+        let result = extractInlineFields(" - [ ] testTask \u{2795}2022-07-25", true);
+        expect(result[0].key).toEqual("created");
+        expect(result[0].value).toEqual("2022-07-25");
+    });
+
+    test("Start date emoji shorthand", () => {
+        let result = extractInlineFields(" - [ ] testTask 🛫2022-07-21", true);
+        expect(result[0].key).toEqual("start");
+        expect(result[0].value).toEqual("2022-07-21");
+    });
+
+    test("Scheduled date emoji shorthand", () => {
+        let result = extractInlineFields(" - [ ] testTask ⏳2022-07-24", true);
+        expect(result[0].key).toEqual("scheduled");
+        expect(result[0].value).toEqual("2022-07-24");
+    });
+});
+
 describe("Set Inline", () => {
     test("Add Annotation", () => {
         let input = "- [ ] an uncompleted task";


### PR DESCRIPTION
- chore: fix prettier errors in existing sources (`main.ts`, `settings.ts`, `lp-render.ts`, `task-view.tsx`)
- refactor: Reduce duplicated code in processing of emoji shorthands in tasks
- feat: Add task emoji shorthands for start and scheduled. Fixes #1003. dataview can now parse all the shorthands used by [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks)
- feat: Add `start` and `scheduled` implicit fields to STask, following convention from `created` `due` and `completion`.
- tests: Add tests for new (and one old) emoji shorthands.
- docs: Document new start and scheduled emoji shorthands on Data Annotation page. Document new `start` and `scheduled` implicit fields in tasks. Fixed a couple of nearby markdownlint errors.