### PR TITLE
chore: fix formatting errors in existing code

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -475,7 +475,7 @@ class GeneralSettingsTab extends PluginSettingTab {
                     await this.plugin.updateSettings({ taskCompletionText: value.trim() });
                 })
             );
-        
+
         new Setting(this.containerEl)
             .setName("Automatic Task Completion Date Format")
             .setDesc(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,7 +10,7 @@ export interface QuerySettings {
     /** The name of the inline field to be added as a task's completion when checked */
     taskCompletionText: string;
     /** Date format of the task's completion timestamp */
-    taskCompletionDateFormat: string,
+    taskCompletionDateFormat: string;
     /** If true, render a modal which shows no results were returned. */
     warnOnEmptyResult: boolean;
     /** Whether or not automatic view refreshing is enabled. */

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -92,7 +92,7 @@ class InlineWidget extends WidgetType {
      */
     ignoreEvent(event: MouseEvent | Event): boolean {
         // instanceof check does not work in pop-out windows, so check it like this
-        if (event.type === 'mousedown') {
+        if (event.type === "mousedown") {
             const currentPos = this.view.posAtCoords({ x: (event as MouseEvent).x, y: (event as MouseEvent).y });
             if ((event as MouseEvent).shiftKey) {
                 // Set the cursor after the element so that it doesn't select starting from the last cursor position.

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -63,7 +63,12 @@ function TaskItem({ item }: { item: STask }) {
 
         let updatedText = undefined;
         if (context.settings.taskCompletionTracking)
-            updatedText = setTaskCompletion(item.text, context.settings.taskCompletionText, context.settings.taskCompletionDateFormat, completed);
+            updatedText = setTaskCompletion(
+                item.text,
+                context.settings.taskCompletionText,
+                context.settings.taskCompletionDateFormat,
+                completed
+            );
 
         rewriteTask(context.app.vault, item, status, updatedText);
     };
@@ -274,11 +279,20 @@ function trimEndingLines(text: string): string {
 }
 
 /** Set the task completion key on check. */
-export function setTaskCompletion(originalText: string, completionKey: string, completionDateFormat: string, complete: boolean): string {
+export function setTaskCompletion(
+    originalText: string,
+    completionKey: string,
+    completionDateFormat: string,
+    complete: boolean
+): string {
     if (!complete) return trimEndingLines(setInlineField(originalText, completionKey, undefined));
 
     let parts = originalText.split(/\r?\n/u);
-    parts[parts.length - 1] = setInlineField(parts[parts.length - 1], completionKey, DateTime.now().toFormat(completionDateFormat));
+    parts[parts.length - 1] = setInlineField(
+        parts[parts.length - 1],
+        completionKey,
+        DateTime.now().toFormat(completionDateFormat)
+    );
     return parts.join("\n");
 }
 


### PR DESCRIPTION
Ran the `format` script to fix the formatting errors in existing code that were being caught in automated testing. No other changes made. No changes to functionality. @AB1908 assuming this passes the automated checks, if you merge this and then rebase your docs branch, your docs branch should then pass all the checks too!