### PR TITLE
feat: Emoji shorthand option for auto task completion

### DIFF
--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -138,10 +138,10 @@ export function extractInlineFields(line: string, includeTaskFields: boolean = f
     if (includeTaskFields) fields = fields.concat(extractSpecialTaskFields(line));
 
     fields.sort((a, b) => a.start - b.start);
-    
+
     let filteredFields: InlineField[] = [];
     for (let i = 0; i < fields.length; i++) {
-        if (i == 0 || filteredFields[filteredFields.length-1].end < fields[i].start) {
+        if (i == 0 || filteredFields[filteredFields.length - 1].end < fields[i].start) {
             filteredFields.push(fields[i]);
         }
     }
@@ -241,13 +241,13 @@ export function setEmojiShorthandCompletionField(source: string, value?: string)
     // Don't do anything if there are duplicate keys OR the key already doesn't exist.
     if (existingKeys.length > 2 || (existingKeys.length == 0 && !value)) return source;
 
-    /* No wrapper, add own spacing */
-    const annotation = value ? ` ✅ ${value} ` : " ";
+    /* No wrapper, add own spacing at start */
+    const annotation = value ? ` ✅ ${value}` : "";
     let existingKey = existingKeys[0];
     if (existingKey) {
         const prefix = source.substring(0, existingKey.start);
         const suffix = source.substring(existingKey.end);
-        return `${prefix.trimEnd()}${annotation}${suffix.trimStart()}`;
+        return `${prefix.trimEnd()}${annotation}${suffix}`;
     } else {
         return `${source.trimEnd()}${annotation}`;
     }

--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -233,3 +233,22 @@ export function setInlineField(source: string, key: string, value?: string): str
 
     return source;
 }
+
+export function setEmojiShorthandCompletionField(source: string, value?: string): string {
+    const existing = extractInlineFields(source, true);
+    const existingKeys = existing.filter(f => f.key === "completion" && f.wrapping === "emoji-shorthand");
+
+    // Don't do anything if there are duplicate keys OR the key already doesn't exist.
+    if (existingKeys.length > 2 || (existingKeys.length == 0 && !value)) return source;
+
+    /* No wrapper, add own spacing */
+    const annotation = value ? ` ✅ ${value} ` : " ";
+    let existingKey = existingKeys[0];
+    if (existingKey) {
+        const prefix = source.substring(0, existingKey.start);
+        const suffix = source.substring(existingKey.end);
+        return `${prefix.trimEnd()}${annotation}${suffix.trimStart()}`;
+    } else {
+        return `${source.trimEnd()}${annotation}`;
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -461,8 +461,15 @@ class GeneralSettingsTab extends PluginSettingTab {
         new Setting(this.containerEl)
             .setName("Automatic Task Completion Tracking")
             .setDesc(
-                "If enabled, Dataview will automatically append tasks with their completion date when they are checked in Dataview views." +
-                    " Example with default field name and date format: - [x] my task [completion:: 2022-01-01]"
+                createFragment(el => {
+                    el.appendText(
+                        "If enabled, Dataview will automatically append tasks with their completion date when they are checked in Dataview views."
+                    );
+                    el.createEl("br");
+                    el.appendText(
+                        "Example with default field name and date format: - [x] my task [completion:: 2022-01-01]"
+                    );
+                })
             )
             .addToggle(toggle =>
                 toggle.setValue(this.plugin.settings.taskCompletionTracking).onChange(async value => {
@@ -478,10 +485,19 @@ class GeneralSettingsTab extends PluginSettingTab {
         if (taskCompletionSubsettingsEnabled)
             taskEmojiShorthand
                 .setDesc(
-                    "If enabled, will use emoji shorthand to fill out the task's implicit Dataview field `completion` instead of inline field formatting." +
-                        " Example: - [x] my task ✅ 2022-01-01" +
-                        " Disable this if you want to customize the completion date format or the field name, or to use Dataview inline field formatting." +
-                        " Only enabled when `Automatic Task Completion Tracking` is enabled."
+                    createFragment(el => {
+                        el.appendText(
+                            'If enabled, will use emoji shorthand instead of inline field formatting to fill out implicit task field "completion".'
+                        );
+                        el.createEl("br");
+                        el.appendText("Example: - [x] my task ✅ 2022-01-01");
+                        el.createEl("br");
+                        el.appendText(
+                            "Disable this to customize the completion date format or field name, or to use Dataview inline field formatting."
+                        );
+                        el.createEl("br");
+                        el.appendText('Only available when "Automatic Task Completion Tracking" is enabled.');
+                    })
                 )
                 .addToggle(toggle =>
                     toggle.setValue(this.plugin.settings.taskCompletionUseEmojiShorthand).onChange(async value => {
@@ -490,7 +506,7 @@ class GeneralSettingsTab extends PluginSettingTab {
                         this.display();
                     })
                 );
-        else taskEmojiShorthand.setDesc("Only enabled when `Automatic Task Completion Tracking` is enabled.");
+        else taskEmojiShorthand.setDesc('Only available when "Automatic Task Completion Tracking" is enabled.');
 
         let taskFieldName = new Setting(this.containerEl)
             .setName("Completion Field Name")
@@ -498,8 +514,15 @@ class GeneralSettingsTab extends PluginSettingTab {
         if (taskCompletionInlineSubsettingsEnabled)
             taskFieldName
                 .setDesc(
-                    "Text used as inline field key to track task completion date when toggling a task's checkbox in a dataview view." +
-                        " Only enabled when `Automatic Task Completion Tracking` is enabled and `Use Emoji Shorthand for Completion` is disabled."
+                    createFragment(el => {
+                        el.appendText(
+                            "Text used as inline field key for task completion date when toggling a task's checkbox in a dataview view."
+                        );
+                        el.createEl("br");
+                        el.appendText(
+                            'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.'
+                        );
+                    })
                 )
                 .addText(text =>
                     text.setValue(this.plugin.settings.taskCompletionText).onChange(async value => {
@@ -508,23 +531,32 @@ class GeneralSettingsTab extends PluginSettingTab {
                 );
         else
             taskFieldName.setDesc(
-                "Only enabled when `Automatic Task Completion Tracking` is enabled and `Use Emoji Shorthand for Completion` is disabled."
+                'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.'
             );
 
         let taskDtFormat = new Setting(this.containerEl)
             .setName("Completion Date Format")
             .setDisabled(!taskCompletionInlineSubsettingsEnabled);
         if (taskCompletionInlineSubsettingsEnabled) {
-            let descText =
-                "Date-time format for tracking task completion date when toggling a task's checkbox in a dataview view (see Luxon date format options)." +
-                " Only enabled when `Automatic Task Completion Tracking` is enabled and `Use Emoji Shorthand for Completion` is disabled." +
-                "Currently: ";
+            let descTextLines = [
+                "Date-time format for task completion date when toggling a task's checkbox in a dataview view (see Luxon date format options).",
+                'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.',
+                "Currently: ",
+            ];
             taskDtFormat
                 .setDesc(
-                    descText +
-                        DateTime.now().toFormat(this.plugin.settings.taskCompletionDateFormat, {
-                            locale: currentLocale(),
-                        })
+                    createFragment(el => {
+                        el.appendText(descTextLines[0]);
+                        el.createEl("br");
+                        el.appendText(descTextLines[1]);
+                        el.createEl("br");
+                        el.appendText(
+                            descTextLines[2] +
+                                DateTime.now().toFormat(this.plugin.settings.taskCompletionDateFormat, {
+                                    locale: currentLocale(),
+                                })
+                        );
+                    })
                 )
                 .addText(text =>
                     text
@@ -532,7 +564,16 @@ class GeneralSettingsTab extends PluginSettingTab {
                         .setValue(this.plugin.settings.taskCompletionDateFormat)
                         .onChange(async value => {
                             taskDtFormat.setDesc(
-                                descText + DateTime.now().toFormat(value.trim(), { locale: currentLocale() })
+                                createFragment(el => {
+                                    el.appendText(descTextLines[0]);
+                                    el.createEl("br");
+                                    el.appendText(descTextLines[1]);
+                                    el.createEl("br");
+                                    el.appendText(
+                                        descTextLines[2] +
+                                            DateTime.now().toFormat(value.trim(), { locale: currentLocale() })
+                                    );
+                                })
                             );
                             await this.plugin.updateSettings({ taskCompletionDateFormat: value.trim() });
                             this.plugin.index.touch();
@@ -540,7 +581,7 @@ class GeneralSettingsTab extends PluginSettingTab {
                 );
         } else {
             taskDtFormat.setDesc(
-                "Only enabled when `Automatic Task Completion Tracking` is enabled and `Use Emoji Shorthand for Completion` is disabled."
+                'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.'
             );
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -355,26 +355,23 @@ class GeneralSettingsTab extends PluginSettingTab {
                 toggle.setValue(this.plugin.settings.refreshEnabled).onChange(async value => {
                     await this.plugin.updateSettings({ refreshEnabled: value });
                     this.plugin.index.touch();
-                    this.display();
                 })
             );
 
-        if (this.plugin.settings.refreshEnabled) {
-            new Setting(this.containerEl)
-                .setName("Refresh Interval")
-                .setDesc("How long to wait (in milliseconds) for files to stop changing before updating views.")
-                .addText(text =>
-                    text
-                        .setPlaceholder("500")
-                        .setValue("" + this.plugin.settings.refreshInterval)
-                        .onChange(async value => {
-                            let parsed = parseInt(value);
-                            if (isNaN(parsed)) return;
-                            parsed = parsed < 100 ? 100 : parsed;
-                            await this.plugin.updateSettings({ refreshInterval: parsed });
-                        })
-                );
-        }
+        new Setting(this.containerEl)
+            .setName("Refresh Interval")
+            .setDesc("How long to wait (in milliseconds) for files to stop changing before updating views.")
+            .addText(text =>
+                text
+                    .setPlaceholder("500")
+                    .setValue("" + this.plugin.settings.refreshInterval)
+                    .onChange(async value => {
+                        let parsed = parseInt(value);
+                        if (isNaN(parsed)) return;
+                        parsed = parsed < 100 ? 100 : parsed;
+                        await this.plugin.updateSettings({ refreshInterval: parsed });
+                    })
+            );
 
         let dformat = new Setting(this.containerEl)
             .setName("Date Format")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,9 +7,11 @@ export interface QuerySettings {
     renderNullAs: string;
     /** If enabled, tasks in Dataview views will automatically have their completion date appended when they are checked. */
     taskCompletionTracking: boolean;
-    /** The name of the inline field to be added as a task's completion when checked */
+    /** If enabled, automatic completions will use emoji shorthand ✅ YYYY-MM-DD instead of [completion:: date]. */
+    taskCompletionUseEmojiShorthand: boolean;
+    /** The name of the inline field to be added as a task's completion when checked. Only used if completionTracking is enabled and emojiShorthand is not. */
     taskCompletionText: string;
-    /** Date format of the task's completion timestamp */
+    /** Date format of the task's completion timestamp. Only used if completionTracking is enabled and emojiShorthand is not. */
     taskCompletionDateFormat: string;
     /** If true, render a modal which shows no results were returned. */
     warnOnEmptyResult: boolean;
@@ -33,6 +35,7 @@ export interface QuerySettings {
 export const DEFAULT_QUERY_SETTINGS: QuerySettings = {
     renderNullAs: "\\-",
     taskCompletionTracking: false,
+    taskCompletionUseEmojiShorthand: false,
     taskCompletionText: "completion",
     taskCompletionDateFormat: "yyyy-MM-dd",
     warnOnEmptyResult: true,

--- a/src/test/parse/parse.inline.test.ts
+++ b/src/test/parse/parse.inline.test.ts
@@ -1,6 +1,6 @@
 import { EXPRESSION } from "expression/parse";
 import { Link } from "data-model/value";
-import { extractInlineFields, setInlineField } from "data-import/inline-field";
+import { extractInlineFields, setEmojiShorthandCompletionField, setInlineField } from "data-import/inline-field";
 
 // <-- Inline field wierd edge cases -->
 
@@ -156,5 +156,17 @@ describe("Set Inline", () => {
 
         result = setInlineField(input, "completion", "2021-02-22");
         expect(result).toEqual("- [x] a completed task [completion:: 2021-02-22] foo bar");
+    });
+
+    test("Add emoji shorthand annotation", () => {
+        let input = "- [ ] an uncompleted task";
+        let result = setEmojiShorthandCompletionField(input);
+        expect(result).toEqual(input);
+
+        result = setEmojiShorthandCompletionField(input, "2022-07-26");
+        expect(result).toEqual(input + " ✅ 2022-07-26 ");
+        const extracted = extractInlineFields(result, true);
+        expect(extracted[0].key).toEqual("completion");
+        expect(extracted[0].value).toEqual("2022-07-26");
     });
 });

--- a/src/test/parse/parse.inline.test.ts
+++ b/src/test/parse/parse.inline.test.ts
@@ -160,13 +160,22 @@ describe("Set Inline", () => {
 
     test("Add emoji shorthand annotation", () => {
         let input = "- [ ] an uncompleted task";
+        /* Nothing added when should not be */
         let result = setEmojiShorthandCompletionField(input);
         expect(result).toEqual(input);
 
+        /* Completion date added */
         result = setEmojiShorthandCompletionField(input, "2022-07-26");
-        expect(result).toEqual(input + " ✅ 2022-07-26 ");
+        expect(result).toEqual(input + " ✅ 2022-07-26");
         const extracted = extractInlineFields(result, true);
         expect(extracted[0].key).toEqual("completion");
         expect(extracted[0].value).toEqual("2022-07-26");
+
+        /* Remove the completion field */
+        result = setEmojiShorthandCompletionField(result);
+        expect(result).toEqual(input);
+        const input2 = "- [x] a completed task ✅ 2022-07-26 foo bar";
+        result = setEmojiShorthandCompletionField(input2);
+        expect(result).toEqual("- [x] a completed task foo bar");
     });
 });

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -1,4 +1,4 @@
-import { extractInlineFields, setInlineField } from "data-import/inline-field";
+import { setEmojiShorthandCompletionField, setInlineField } from "data-import/inline-field";
 import { LIST_ITEM_REGEX } from "data-import/markdown-file";
 import { SListEntry, SListItem, STask } from "data-model/serialized/markdown";
 import { Grouping, Groupings } from "data-model/value";
@@ -290,23 +290,12 @@ export function setTaskCompletion(
     if (!complete && !useEmojiShorthand) return trimEndingLines(setInlineField(originalText, completionKey));
 
     let parts = originalText.split(/\r?\n/u);
-    if (useEmojiShorthand) {
-        const existingKeys = extractInlineFields(parts[parts.length - 1], true).filter(
-            f => f.key === "completion" && f.wrapping === "emoji-shorthand"
-        );
 
-        // Only set completion if there are no duplicates AND the field must be changed (date set or key removed).
-        if (existingKeys.length <= 2 && (complete || existingKeys.length > 0)) {
-            /* No wrapper, add own spacing */
-            const annotation = complete ? ` ✅ ${DateTime.now().toFormat("yyyy-MM-dd")} ` : " ";
-            if (existingKeys[0]) {
-                const prefix = parts[parts.length - 1].substring(0, existingKeys[0].start);
-                const suffix = parts[parts.length - 1].substring(existingKeys[0].end);
-                parts[parts.length - 1] = `${prefix.trimEnd()}${annotation}${suffix.trimStart()}`;
-            } else {
-                parts[parts.length - 1] = `${parts[parts.length - 1].trimEnd()}${annotation}`;
-            }
-        }
+    if (useEmojiShorthand) {
+        parts[parts.length - 1] = setEmojiShorthandCompletionField(
+            parts[parts.length - 1],
+            complete ? DateTime.now().toFormat("yyyy-MM-dd") : ""
+        );
     } else {
         parts[parts.length - 1] = setInlineField(
             parts[parts.length - 1],

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -287,11 +287,10 @@ export function setTaskCompletion(
     completionDateFormat: string,
     complete: boolean
 ): string {
-    if (!complete && !useEmojiShorthand) return trimEndingLines(setInlineField(originalText, completionKey, undefined));
+    if (!complete && !useEmojiShorthand) return trimEndingLines(setInlineField(originalText, completionKey));
 
     let parts = originalText.split(/\r?\n/u);
     if (useEmojiShorthand) {
-        console.log(`Emoji shorthand time! Original text: ${originalText}, complete: ${complete}`);
         const existingKeys = extractInlineFields(parts[parts.length - 1], true).filter(
             f => f.key === "completion" && f.wrapping === "emoji-shorthand"
         );


### PR DESCRIPTION
Allows users to specify a setting (off by default) to use the emoji shorthand ✅ already read by Dataview as the annotation for automatic task completion. This achieves compatibility with the obsidian-tasks plugin behavior while still keeping the completion date readable by dataview implicit field `completion`. 
Fixes issues #815  and #1273  (modulo spacing) and possibly others.

Added a couple automated tests for the emoji completion similar to what is present for text completion. I also tested both old and new settings combinations manually with the test vault on Windows. Also tested in combination with the obsidian-tasks plugin in the test vault on Windows. With the new setting enabled and the default Tasks plugin settings, checking a checkbox now gives the same behavior across dataview views, Tasks queries, and the task text itself in Live Preview and Reading mode. 

* feat: Allow emoji shorthand for task completion in Dataview views
* feat: New setting for emoji shorthand in task completion. The setting toggle is only visible if the toggle for automatic task completion is enabled. If the emoji shorthand setting is enabled, the inputs for completion field name and date format are hidden, since they are ignored. If the emoji shorthand setting is disabled (default), the completion field name and date format inputs are shown as normal.
* test: Automated tests for setEmojiShorthandCompletionField

**Outstanding question**: How to handle `[completion:: date]` and `✅ date2` annotations on the same task? Or the existence of one when the annotation style is set to the other?
Current behavior is that both ignore the other type of annotation. The existing `setInlineField` does not pass the parameter needed to even see tasks shorthand fields when adding or removing an annotation. So I made the equivalent replacement behavior for the emoji shorthand only match `completion` annotations that also are in emoji shorthand.
This option is less destructive to data in the task at the expense of potential confusion during querying since `completion` might have two values. Does anyone have thoughts about the best thing to do in this situation?

~~**Looking for feedback**: Feedback welcome on the wording of the new settings option near the bottom of "Settings" -> "Dataview" - thank you in advance!~~