### PR TITLE
Fixes #1445 - Date +/- null resolves null

### DIFF
--- a/src/expression/binaryop.ts
+++ b/src/expression/binaryop.ts
@@ -134,5 +134,9 @@ export function createBinaryOps(linkNormalizer: (x: string) => string): BinaryOp
             .register("null", "*", "null", (_a, _b) => null)
             .register("null", "/", "null", (_a, _b) => null)
             .register("null", "%", "null", (_a, _b) => null)
+            .register("date", "+", "null", (_a, _b) => null)
+            .register("null", "+", "date", (_a, _b) => null)
+            .register("date", "-", "null", (_a, _b) => null)
+            .register("null", "-", "date", (_a, _b) => null)
     );
 }

--- a/src/test/parse/parse.expression.test.ts
+++ b/src/test/parse/parse.expression.test.ts
@@ -396,6 +396,38 @@ test("Parse function with duration", () => {
     );
 });
 
+test("Parse null duration", () => {
+    expect(EXPRESSION.field.tryParse("dur(null)")).toEqual(Fields.func(Fields.variable("dur"), [Fields.literal(null)]));
+    expect(EXPRESSION.field.tryParse('dur("null")')).toEqual(Fields.func(Fields.variable("dur"), [Fields.literal("null")]));
+});
+
+test("Parse function with null duration", () => {
+    expect(EXPRESSION.field.tryParse("today() + dur(null)")).toEqual(
+        Fields.binaryOp(
+            Fields.func(Fields.variable("today"), []),
+            "+",
+            Fields.func(Fields.variable("dur"), [Fields.literal(null)])
+        )
+    );
+});
+
+test("Parse date +/- null", () => {
+    expect(EXPRESSION.field.tryParse("today() + null")).toEqual(
+        Fields.binaryOp(
+            Fields.func(Fields.variable("today"), []),
+            "+",
+            Fields.literal(null)
+        )
+    );
+    expect(EXPRESSION.field.tryParse("today() - null")).toEqual(
+        Fields.binaryOp(
+            Fields.func(Fields.variable("today"), []),
+            "-",
+            Fields.literal(null)
+        )
+    );
+});
+
 test("Parse function with mixed dot, index, and function call", () => {
     expect(EXPRESSION.field.tryParse("list().parts[0]")).toEqual(
         Fields.index(Fields.index(Fields.func(Fields.variable("list"), []), Fields.literal("parts")), Fields.literal(0))


### PR DESCRIPTION
Fixes #1445 Date and null arithmetic operations ending in error. 

This can occur when using the `dur()` function on a possibly-undefined key to offset a date, and therefore should not cause errors in parsing.

Example test:
```
- [ ] %% ➕2022-09-22 #todo [[todos]] %%(context:: [[reminder]]) [in:: 1 days] Check this off
- [ ] %% ➕2022-09-23 #todo [[todos]] %%(context:: [[reminder]]) 📆2022-09-23 Check this off

\```dataview
TASK FROM #todo 
WHERE context = [[reminder]]
    and (!completed or completion = date(today))
    and (
        (due & date(today) >= due)
     or (in & date(today) >= date(created) + dur(in))
    )
\```
```

After change:
![image](https://user-images.githubusercontent.com/16886725/192056867-45cc4524-ce4a-47c5-a63a-7ce33c1b0d30.png)
![image](https://user-images.githubusercontent.com/16886725/192056959-a5d745fe-c19a-4adf-a0bd-5a321f9c6926.png)
