### PR TITLE
More block id task completion fixes

### DIFF
--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -313,10 +313,10 @@ export function setTaskCompletion(
     const matches = blockIdRegex.exec(parts[parts.length - 1]);
     console.debug("matchreg", matches);
     if (useEmojiShorthand) {
-        parts[parts.length - 1] = setEmojiShorthandCompletionField(
-            parts[parts.length - 1],
+        parts[parts.length - 1] = `${setEmojiShorthandCompletionField(
+            parts[parts.length - 1].split(blockIdRegex).join(""),
             complete ? DateTime.now().toFormat("yyyy-MM-dd") : ""
-        );
+        )}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd();
     } else {
         parts[parts.length - 1] = `${setInlineField(
             parts[parts.length - 1].split(blockIdRegex).join(""),

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -316,13 +316,13 @@ export function setTaskCompletion(
         parts[parts.length - 1] = `${setEmojiShorthandCompletionField(
             parts[parts.length - 1].split(blockIdRegex).join(""),
             complete ? DateTime.now().toFormat("yyyy-MM-dd") : ""
-        )}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd();
+        ).trimEnd()}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd();
     } else {
         parts[parts.length - 1] = `${setInlineField(
             parts[parts.length - 1].split(blockIdRegex).join(""),
             completionKey,
             DateTime.now().toFormat(completionDateFormat)
-        )}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd();
+        ).trimEnd()}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd();
     }
     return parts.join("\n");
 }

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -312,18 +312,23 @@ export function setTaskCompletion(
     let parts = originalText.split(/\r?\n/u);
     const matches = blockIdRegex.exec(parts[parts.length - 1]);
     console.debug("matchreg", matches);
+
+    let processedPart = parts[parts.length - 1].split(blockIdRegex).join(""); // last part without block id
     if (useEmojiShorthand) {
-        parts[parts.length - 1] = `${setEmojiShorthandCompletionField(
-            parts[parts.length - 1].split(blockIdRegex).join(""),
+        processedPart = setEmojiShorthandCompletionField(
+            processedPart,
             complete ? DateTime.now().toFormat("yyyy-MM-dd") : ""
-        ).trimEnd()}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd();
+        )
     } else {
-        parts[parts.length - 1] = `${setInlineField(
-            parts[parts.length - 1].split(blockIdRegex).join(""),
+        processedPart = setInlineField(
+            processedPart,
             completionKey,
             DateTime.now().toFormat(completionDateFormat)
-        ).trimEnd()}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd();
+        )
     }
+    processedPart = `${processedPart.trimEnd()}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd(); // add back block id
+    parts[parts.length - 1] = processedPart
+
     return parts.join("\n");
 }
 

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -304,7 +304,7 @@ export function setTaskCompletion(
     completionDateFormat: string,
     complete: boolean
 ): string {
-    const blockIdRegex = /\^[a-z0-9\-]+\s/i;
+    const blockIdRegex = /\^[a-z0-9\-]+/i;
 
     if (!complete && !useEmojiShorthand)
         return trimEndingLines(setInlineField(originalText.trimEnd(), completionKey)).trimEnd();
@@ -322,7 +322,7 @@ export function setTaskCompletion(
             parts[parts.length - 1].split(blockIdRegex).join(""),
             completionKey,
             DateTime.now().toFormat(completionDateFormat)
-        )}${matches?.length ? "" + matches[0].trim() : ""}`.trimEnd();
+        )}${matches?.length ? " " + matches[0].trim() : ""}`.trimEnd();
     }
     return parts.join("\n");
 }


### PR DESCRIPTION
Has lately been following #699, and was excited to see #1485 land in the repository. However, upon checking out and building master (or the latest commit that builds, `dbd993f`), I still had the issue of block ids not being detected by the regex (can be confirmed by enabling verbose logging in DevTools and looking for the output of https://github.com/blacksmithgu/obsidian-dataview/blob/dbd993fbbcc337459bfb7da8910ae23102bc1adb/src/ui/views/task-view.tsx#L314, which is `matchreg: null`).

After troubleshooting a bit, I noticed that the `blockIdRegex` assumes a whitespace character at the end of the line, while the syntax for block ids is that they should be at the end of the line with no whitespace after. I also noticed that the previous pull request failed to also implement block id detection for emoji shorthand, which is also added in this PR.

Tested with both emoji shorthand enabled and disabled. Closes #699 (again).