### PR TITLE
docs(overview): enhance Overview page with "How to Use Dataview" section

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -116,7 +116,7 @@ FROM #poems
 
 This'll give you back a result like:
 
-| File (2) |	author |	published	| Mentions |
+| File (3) |	author |	published	| Mentions |
 | -------- | ------- | ---------- | -------- |
 | The Bells |	Edgar Allan Poe |	1849 |  |	
 | The New Colossus |	Emma Lazarus | 1883	| - [[Favorite Poems]] |	
@@ -133,7 +133,7 @@ FROM #poems
 
 gives you back
 
-| File (2) |	author |	Age in Yrs	| Count of Mentions |
+| File (3) |	author |	Age in Yrs	| Count of Mentions |
 | -------- | ------- | ---------- | -------- |
 | The Bells	|  Edgar Allan Poe |	173 | 0 |
 | The New Colossus	| Emma Lazarus |	139 |	1 |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -31,7 +31,7 @@ Dataview consists of two big building blocks: **Data Indexing** and **Data Query
 
 ### Data Indexing
 
-Dataview operates on metadata in your Markdown files and it cannot read everything in your vault. Some of your content, like tags and bullet points (including tasks), are [available automatically](annotation/add-metadata.md#implicit-fields) in Dataview. You can add other data through **fields**, either on top of your file [per YAML Frontmatter](annotation/add-metadata.md#frontmatter) or in the middle of your content with [Inline Fields](annotation/add-metadata.md#inline-fields) via the `[key:: value]` syntax. Dataview _indexes_ these data to make it available for you to query. 
+Dataview operates on metadata in your Markdown files. It cannot read everything in your vault, but only specific data. Some of your content, like tags and bullet points (including tasks), are [available automatically](annotation/add-metadata.md#implicit-fields) in Dataview. You can add other data through **fields**, either on top of your file [per YAML Frontmatter](annotation/add-metadata.md#frontmatter) or in the middle of your content with [Inline Fields](annotation/add-metadata.md#inline-fields) via the `[key:: value]` syntax. Dataview _indexes_ these data to make it available for you to query. 
 
 !!! hint "Dataview indexes [certain information](annotation/add-metadata.md#implicit-fields) like tags and list items and the data you add via fields. Only indexed data is available in a Dataview query!"
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,6 +1,7 @@
 # Overview
 
-Dataview is a live index and query engine over your personal knowledge base. You can **add metadata** to your notes and **query** them to list, filter, sort or group them - dataview keeps your queries always up to date and makes data aggregation a breeze.
+Dataview is a live index and query engine over your personal knowledge base. You can [**add metadata**](annotation/add-metadata.md) to your notes and **query** them with the [**Dataview Query Language**](queries/structure.md) to list, filter, sort or group your data. Dataview keeps your queries always up to date and makes data aggregation a breeze.
+
 You could
 
 - Track your sleep by recording it in daily notes, and automatically create weekly tables of your sleep schedule.
@@ -11,14 +12,15 @@ You could
 
 and many, many things more.
 
+!!! hint "Dataview gives you a fast way to search, display and operate on indexed data in your vault!"
+
 Dataview is highly generic and high performance, scaling up to hundreds of thousands of annotated notes without issue. 
-**Dataview gives you a fast way to search, display and operate on indexed data**. 
 
 If the built in [query language](query/queries/) is insufficient for your purpose, you can run arbitrary
 JavaScript against the [dataview API](api/intro/) and build whatever utility you might need yourself, right in your notes.
 
 !!! info "Dataview is about displaying, not editing"
-    Dataview is meant for displaying and calculating data. It is no utility to edit data in your source files and will keep your notes always untouched (... except you're checking a [Task](queries/query-types.md#task-queries) through Dataview.)
+    Dataview is meant for displaying and calculating data. It is no utility to edit data in your source files and will keep your notes always untouched (... except if you're checking a [Task](queries/query-types.md#task-queries) through Dataview.)
 
 ## How to Use Dataview
 
@@ -29,7 +31,7 @@ Dataview consists out of two big building blocks: **Data Indexing** and **Data Q
 
 ### Data Indexing
 
-Dataview cannot read all your vault, but operates on specific data. Some of your content, like tags and bullet points (including tasks), are [available automatically](annotation/add-metadata.md#implicit-fields) in Dataview, and you can add other through **fields**, either on top of your file [per YAML Frontmatter](annotation/add-metadata.md#frontmatter) or in the middle of your content with [Inline Fields](annotation/add-metadata.md#inline-fields) via the `[key:: value]` syntax. Dataview _indexes_ these data to make it available for you to query. 
+Dataview cannot read all your vault, but operates on specific data. Some of your content, like tags and bullet points (including tasks), are [available automatically](annotation/add-metadata.md#implicit-fields) in Dataview. You can add other data through **fields**, either on top of your file [per YAML Frontmatter](annotation/add-metadata.md#frontmatter) or in the middle of your content with [Inline Fields](annotation/add-metadata.md#inline-fields) via the `[key:: value]` syntax. Dataview _indexes_ these data to make it available for you to query. 
 
 !!! hint "Only indexed data is available through Dataview!"
 
@@ -70,8 +72,6 @@ You can access **indexed data** with the help of **Queries**.
 There are **three different ways** you can write a Query: With help of the [Dataview Query Language](queries/dql-js-inline/#dataview-query-language-dql), as an [inline statement](queries/dql-js-inline#inline-dql) or in the most flexible and most complex way: as a [Javascript Query](queries/dql-js-inline#dataview-js). 
 
 The **Dataview Query Language** (short **DQL**) gives you a broad and powerful toolbelt to query, display and operate on your data. An [**inline query**](queries/dql-js-inline#inline-dql) gives you the possibility to display exactly one indexed value anywhere in your note. You can also do calculations this way. With **DQL** at your hands, you'll be probably fine without any Javascript throurough your data journey.
-
-Let's concentrate on the Dataview Query Language (DQL).
 
 A DQL Query consists of several parts:
 
@@ -116,11 +116,13 @@ FROM #poems
 
 This'll give you back a result like:
 
-| File (1) |	author |	published	| Mentions |
+| File (2) |	author |	published	| Mentions |
 | -------- | ------- | ---------- | -------- |
 | The Raven |	Edgar Allan Poe |	1845 | - [[Favorite Poems]] |	
+| The Bells |	Edgar Allan Poe |	1849 |  |	
+| The New Colossus |	Emma Lazarus | 1883	| - [[Favorite Poems]] |	
 
-That's not where the capabilities of dataview end, though. You can also **perform operations** on your values. Mind that these operations are only made inside your query - your **data in your files stays untouched**.
+That's not where the capabilities of dataview end, though. You can also **perform operations** with help of [**functions**](reference/functions.md) on your values. Mind that these operations are only made inside your query - your **data in your files stays untouched**.
 
 ~~~markdown
 ```dataview
@@ -131,9 +133,11 @@ FROM #poems
 
 gives you back
 
-| File (1) |	author |	Age in Yrs	| Count of Mentions |
+| File (2) |	author |	Age in Yrs	| Count of Mentions |
 | -------- | ------- | ---------- | -------- |
 | The Raven |	Edgar Allan Poe |	177 | 1 |	
+| The Bells	|  Edgar Allan Poe |	173 | 0 |
+|The New Colossus	| Emma Lazarus |	139 |	1 |
 
 As you can see, dataview doesn't only allow you to aggregate your data swiftly and always up to date, it also can help you with operations to give you new insights on your dataset. Browse through the documentation to find out more on how to interact with your data - have fun exploring your vault! 
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,96 +1,142 @@
 # Overview
 
-Dataview is a live index and query engine over your knowledge base. You can associate *data* (like tags, dates,
-snippets, numbers, and so on) with your markdown pages, and then *query* (like filter, sort, transform) this data. This
-is a simple but powerful idea:
+Dataview is a live index and query engine over your personal knowledge base. You can **add metadata** to your notes and **query** them to list, filter, sort or group them - dataview keeps your queries always up to date and makes data aggregation a breeze.
+You could
 
-- Track sleep schedules and habits by recording them in daily notes, and automatically create weekly tables of your
-  sleep schedule.
+- Track your sleep by recording it in daily notes, and automatically create weekly tables of your sleep schedule.
 - Automatically collect links to books in your notes, and render them all sorted by rating.
-- Automatically collect pages annotated with a given date, showing them in your daily note or elsewhere.
+- Automatically collect pages associated with today's date and show them in your daily note.
 - Find pages with no tags for follow-up, or show pretty views of specifically-tagged pages.
-- Create dynamic views which show upcoming birthdays or events, annotated with notes.
+- Create dynamic views which show upcoming birthdays or events recorded in your notes
 
-Dataview is highly generic and high performance, scaling up to hundreds of thousands of annotated notes without
-issue. If the built in [query language](query/queries/) is insufficient for your purpose, you can run arbitrary
-JavaScript against the [dataview API](api/intro/).
+and many, many things more.
 
-## Basic Usage
+Dataview is highly generic and high performance, scaling up to hundreds of thousands of annotated notes without issue. 
+**Dataview gives you a fast way to search, display and operate on indexed data**. 
 
-Dataview has two major components: *annotation* and *querying*. Each operates largely independently and are described below.
+If the built in [query language](query/queries/) is insufficient for your purpose, you can run arbitrary
+JavaScript against the [dataview API](api/intro/) and build whatever utility you might need yourself, right in your notes.
 
-#### Annotation
+!!! info "Dataview is about displaying, not editing"
+    Dataview is meant for displaying and calculating data. It is no utility to edit data in your source files and will keep your notes always untouched (... except you're checking a [Task](queries/query-types.md#task-queries) through Dataview.)
 
-The dataview **index** is responsible for constantly parsing markdown files and other metadata in your vault, creating
-an in-memory index which allows for fast queries over your data. Annotation is done at the *markdown page*, *section*,
-and *task* level, where you can either use:
+## How to Use Dataview
 
-1. **Frontmatter**, a common Markdown extension which allows for adding arbitrary YAML at the top of a document):
-    ```yaml
-    ---
-    alias: "document"
-    last-reviewed: 2021-08-17
-    thoughts:
-      rating: 8
-      reviewable: false
-    ---
-    ```
-2. **Inline Fields**, a Dataview-specific way to provide metadata in an intuitive `Key:: Value` syntax:
-    ```markdown
-    # Markdown Page
+Dataview consists out of two big building blocks: **Data Indexing** and **Data Querying**. 
 
-    Some text, and then [Inline Field:: Value] [Another Inline Field On The Same Line:: With A New Value!]
+!!! info "More details on the linked documentation pages"
+    The following sections should give you a broad overview about what you can do with dataview and how. Be sure to visit the linked pages to find out more about the individual parts.
 
-    Basic Field:: Value
-    **Bold Field**:: Nice!
+### Data Indexing
 
-    - [ ] I am a task with [metadata::value]!
-      - [X] I am another task with completed::2020-09-15
-    ```
+Dataview cannot read all your vault, but operates on specific data. Some of your content, like tags and bullet points (including tasks), are [available automatically](annotation/add-metadata.md#implicit-fields) in Dataview, and you can add other through **fields**, either on top of your file [per YAML Frontmatter](annotation/add-metadata.md#frontmatter) or in the middle of your content with [Inline Fields](annotation/add-metadata.md#inline-fields) via the `[key:: value]` syntax. Dataview _indexes_ these data to make it available for you to query. 
 
-You can combine both methods if desired. Dataview also adds a significant number
-of "implicit" fields, like `file.name` for the file name, `file.size` for the
-size, and so on; you can find more details in the [data annotation documentation](data-annotation).
+!!! hint "Only indexed data is available through Dataview!"
 
-#### Querying
+For example, a file might look like this:
 
-Once you have some pages that you've annotated, all that's left to do is query them to create dynamic table, list, or
-JavaScript views. There are four ways to do this:
+```markdown
+---
+author: "Edgar Allan Poe"
+published: 1845
+tags: poems
+---
 
-1. **Dataview Query Language (DQL)**: A pipeline-based, vaguely SQL-looking expression language which can support basic
-   use cases. See the [guide](writing-dql) for an overview of how to use DQL, or check out the [reference material](query/queries/) for details.
+# The Raven
 
-    ~~~markdown
-    ```dataview
-    TABLE file.name AS "File", rating AS "Rating" FROM #book
-    ```
-    ~~~
+Once upon a midnight dreary, while I pondered, weak and weary,
+Over many a quaint and curious volume of forgotten lore—
+```
 
-2. **Inline Expressions**: DQL expressions which you can embed directly inside markdown and which will be evaluated in
-   preview mode. See the [documentation](query/expressions/) for
-   allowable queries.
+Or like this:
 
-    ```markdown
-    We are on page `= this.file.name`.
-    ```
+```markdown
+#poems
 
-3. **DataviewJS**: A high-powered JavaScript API which gives full access to the Dataview index and some convenient
-   rendering utilities. Highly recommended if you know JavaScript, since this is far more powerful than the query
-   language. Check the [documentation](api/intro/) for more details.
+# The Raven
 
-    ~~~markdown
-    ```dataviewjs
-    dv.taskList(dv.pages().file.tasks.where(t => !t.completed));
-    ```
-    ~~~
+From [author:: Edgar Allan Poe], written in (published:: 1845)
 
-4. **Inline JS Expressions**: The JavaScript equivalent to inline expressions, which allow you to execute arbitrary JS
-   inline:
+Once upon a midnight dreary, while I pondered, weak and weary,
+Over many a quaint and curious volume of forgotten lore—
+```
 
-    ~~~markdown
-    This page was last modified at `$= dv.current().file.mtime`.
-    ~~~
+Data-wise, they are identical and only differ in your preffered way how you want to add your [metadata](annotation/add-metadata.md). With this file, you'd have the **metadata field** `author` available and everything Dataview provides you [automatically as implicit fields](annotation/metadata-pages.md), like the tag or note title.
+
+### Data Querying
+
+You can access **indexed data** with the help of **Queries**.
+
+There are **three different ways** you can write a Query: With help of the [Dataview Query Language](queries/dql-js-inline/#dataview-query-language-dql), as an [inline statement](queries/dql-js-inline#inline-dql) or in the most flexible and most complex way: as a [Javascript Query](queries/dql-js-inline#dataview-js). 
+
+The **Dataview Query Language** (short **DQL**) gives you a broad and powerful toolbelt to query, display and operate on your data. An [**inline query**](queries/dql-js-inline#inline-dql) gives you the possibility to display exactly one indexed value anywhere in your note. You can also do calculations this way. With **DQL** at your hands, you'll be probably fine without any Javascript throurough your data journey.
+
+Let's concentrate on the Dataview Query Language (DQL).
+
+A DQL Query consists of several parts:
+
+- Exactly one [**Query Type**](queries/query-types.md) that determines how your Query Output looks like
+- None or one [**FROM statement**](queries/data-commands#from) to pick a specific tag or folder (or another [source](reference/sources.md)) to look at
+- None to multiple [**other Data Commands**](queries/data-commands.md) that help you filter, group and sort your wanted output
+
+For example, a Query can look like this:
+
+~~~markdown
+```dataview
+LIST
+```
+~~~
+
+which list all files in your vault. 
+
+!!! info "Everything but the Query Type is optional"
+    The only thing you need for a valid DQL Query is the Query Type (and on [CALENDAR](queries/query-types#calendar-queries)s, a date field.)
+
+ A more restricted Query might look like this:
+
+~~~markdown
+```dataview
+LIST
+FROM #poems
+WHERE author = "Edgar Allan Poe"
+```
+~~~
+
+which lists all files in your vault that have the tag `#poems` and a [field](annotation/add-metadata.md) named `author` with the value `Edgar Allan Poe`. This query would find our example page from above. 
+
+`LIST` is only one out of four [Query Types](queries/query-types.md) you can use. For example, with a `TABLE`, we could add some more information to our output: 
+
+
+~~~markdown
+```dataview
+TABLE author, published, file.inlinks AS "Mentions"
+FROM #poems
+```
+~~~
+
+This'll give you back a result like:
+
+| File (1) |	author |	published	| Mentions |
+| -------- | ------- | ---------- | -------- |
+| The Raven |	Edgar Allan Poe |	1845 | - [[Favorite Poems]] |	
+
+That's not where the capabilities of dataview end, though. You can also **perform operations** on your values. Mind that these operations are only made inside your query - your **data in your files stays untouched**.
+
+~~~markdown
+```dataview
+TABLE author, date(now).year - published AS "Age in Yrs", length(file.inlinks) AS "Counts of Mentions"
+FROM #poems
+```
+~~~
+
+gives you back
+
+| File (1) |	author |	Age in Yrs	| Count of Mentions |
+| -------- | ------- | ---------- | -------- |
+| The Raven |	Edgar Allan Poe |	177 | 1 |	
+
+As you can see, dataview doesn't only allow you to aggregate your data swiftly and always up to date, it also can help you with operations to give you new insights on your dataset. Browse through the documentation to find out more on how to interact with your data - have fun exploring your vault! 
 
 ## Resources and Help
 
-See [getting started](./resources/resources-and-support.md) for a list of resources and how to find support.
+This documentation is not the only place that can help you out on your data journey. Take a look at [Resources and Support](./resources/resources-and-support.md) for a list of helpful pages and places.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -31,9 +31,9 @@ Dataview consists of two big building blocks: **Data Indexing** and **Data Query
 
 ### Data Indexing
 
-Dataview cannot read all your vault, but operates on specific data. Some of your content, like tags and bullet points (including tasks), are [available automatically](annotation/add-metadata.md#implicit-fields) in Dataview. You can add other data through **fields**, either on top of your file [per YAML Frontmatter](annotation/add-metadata.md#frontmatter) or in the middle of your content with [Inline Fields](annotation/add-metadata.md#inline-fields) via the `[key:: value]` syntax. Dataview _indexes_ these data to make it available for you to query. 
+Dataview operates on metadata in your Markdown files and it cannot read everything in your vault. Some of your content, like tags and bullet points (including tasks), are [available automatically](annotation/add-metadata.md#implicit-fields) in Dataview. You can add other data through **fields**, either on top of your file [per YAML Frontmatter](annotation/add-metadata.md#frontmatter) or in the middle of your content with [Inline Fields](annotation/add-metadata.md#inline-fields) via the `[key:: value]` syntax. Dataview _indexes_ these data to make it available for you to query. 
 
-!!! hint "Only indexed data is available through Dataview!"
+!!! hint "Dataview indexes [certain information](annotation/add-metadata.md#implicit-fields) like tags and list items and the data you add via fields. Only indexed data is available in a Dataview query!"
 
 For example, a file might look like this:
 
@@ -63,7 +63,10 @@ Once upon a midnight dreary, while I pondered, weak and weary,
 Over many a quaint and curious volume of forgotten lore—
 ```
 
-In terms of indexed metadata (or what you can query), they are identical, and only differ in their annotation style. How you want to [annotate your  metadata](annotation/add-metadata.md) is up to you and your personal preference. With this file, you'd have the **metadata field** `author` available and everything Dataview provides you [automatically as implicit fields](annotation/metadata-pages.md), like the tag or note title.
+In terms of indexed metadata (or what you can query), they are identical, and only differ in their annotation style. How you want to [annotate your  metadata](annotation/add-metadata.md) is up to you and your personal preference. With this file, you'd have the **metadata field** `author` available and everything Dataview provides you [automatically as implicit fields](annotation/metadata-pages.md), like the tag or note title. 
+
+!!! attention "Data needs to be indexed"
+    In the above example, you _do not_ have the poem itself available in Dataview: It is a paragraph, no metadata field and nothing Dataview indexes automatically. It is not part of Dataviews index, so you won't be able to query it.
 
 ### Data Querying
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -118,9 +118,9 @@ This'll give you back a result like:
 
 | File (2) |	author |	published	| Mentions |
 | -------- | ------- | ---------- | -------- |
-| The Raven |	Edgar Allan Poe |	1845 | - [[Favorite Poems]] |	
 | The Bells |	Edgar Allan Poe |	1849 |  |	
 | The New Colossus |	Emma Lazarus | 1883	| - [[Favorite Poems]] |	
+| The Raven |	Edgar Allan Poe |	1845 | - [[Favorite Poems]] |	
 
 That's not where the capabilities of dataview end, though. You can also **perform operations** with help of [**functions**](reference/functions.md) on your values. Mind that these operations are only made inside your query - your **data in your files stays untouched**.
 
@@ -135,9 +135,11 @@ gives you back
 
 | File (2) |	author |	Age in Yrs	| Count of Mentions |
 | -------- | ------- | ---------- | -------- |
-| The Raven |	Edgar Allan Poe |	177 | 1 |	
 | The Bells	|  Edgar Allan Poe |	173 | 0 |
-|The New Colossus	| Emma Lazarus |	139 |	1 |
+| The New Colossus	| Emma Lazarus |	139 |	1 |
+| The Raven |	Edgar Allan Poe |	177 | 1 |	
+
+!!! info "Find more examples [here](resources/examples.md)."
 
 As you can see, dataview doesn't only allow you to aggregate your data swiftly and always up to date, it also can help you with operations to give you new insights on your dataset. Browse through the documentation to find out more on how to interact with your data - have fun exploring your vault! 
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,7 +10,7 @@ You could
 - Find pages with no tags for follow-up, or show pretty views of specifically-tagged pages.
 - Create dynamic views which show upcoming birthdays or events recorded in your notes
 
-and many, many things more.
+and many more things.
 
 !!! hint "Dataview gives you a fast way to search, display and operate on indexed data in your vault!"
 
@@ -20,14 +20,14 @@ If the built in [query language](query/queries/) is insufficient for your purpos
 JavaScript against the [dataview API](api/intro/) and build whatever utility you might need yourself, right in your notes.
 
 !!! info "Dataview is about displaying, not editing"
-    Dataview is meant for displaying and calculating data. It is no utility to edit data in your source files and will keep your notes always untouched (... except if you're checking a [Task](queries/query-types.md#task-queries) through Dataview.)
+    Dataview is meant for displaying and calculating data. It is not meant to edit your notes/metadata and will always leave them untouched (... except if you're checking a [Task](queries/query-types.md#task-queries) through Dataview.)
 
 ## How to Use Dataview
 
-Dataview consists out of two big building blocks: **Data Indexing** and **Data Querying**. 
+Dataview consists of two big building blocks: **Data Indexing** and **Data Querying**. 
 
 !!! info "More details on the linked documentation pages"
-    The following sections should give you a broad overview about what you can do with dataview and how. Be sure to visit the linked pages to find out more about the individual parts.
+    The following sections should give you a general overview about what you can do with dataview and how. Be sure to visit the linked pages to find out more about the individual parts.
 
 ### Data Indexing
 
@@ -63,19 +63,19 @@ Once upon a midnight dreary, while I pondered, weak and weary,
 Over many a quaint and curious volume of forgotten lore—
 ```
 
-Data-wise, they are identical and only differ in your preffered way how you want to add your [metadata](annotation/add-metadata.md). With this file, you'd have the **metadata field** `author` available and everything Dataview provides you [automatically as implicit fields](annotation/metadata-pages.md), like the tag or note title.
+In terms of indexed metadata (or what you can query), they are identical, and only differ in their annotation style. How you want to [annotate your  metadata](annotation/add-metadata.md) is up to you and your personal preference. With this file, you'd have the **metadata field** `author` available and everything Dataview provides you [automatically as implicit fields](annotation/metadata-pages.md), like the tag or note title.
 
 ### Data Querying
 
 You can access **indexed data** with the help of **Queries**.
 
-There are **three different ways** you can write a Query: With help of the [Dataview Query Language](queries/dql-js-inline/#dataview-query-language-dql), as an [inline statement](queries/dql-js-inline#inline-dql) or in the most flexible and most complex way: as a [Javascript Query](queries/dql-js-inline#dataview-js). 
+There are **three different ways** you can write a Query: With help of the [Dataview Query Language](queries/dql-js-inline/#dataview-query-language-dql), as an [inline statement](queries/dql-js-inline#inline-dql) or in the most flexible but most complex way: as a [Javascript Query](queries/dql-js-inline#dataview-js). 
 
-The **Dataview Query Language** (short **DQL**) gives you a broad and powerful toolbelt to query, display and operate on your data. An [**inline query**](queries/dql-js-inline#inline-dql) gives you the possibility to display exactly one indexed value anywhere in your note. You can also do calculations this way. With **DQL** at your hands, you'll be probably fine without any Javascript throurough your data journey.
+The **Dataview Query Language** (**DQL**) gives you a broad and powerful toolbelt to query, display and operate on your data. An [**inline query**](queries/dql-js-inline#inline-dql) gives you the possibility to display exactly one indexed value anywhere in your note. You can also do calculations this way. With **DQL** at your hands, you'll be probably fine without any Javascript throurough your data journey.
 
 A DQL Query consists of several parts:
 
-- Exactly one [**Query Type**](queries/query-types.md) that determines how your Query Output looks like
+- Exactly one [**Query Type**](queries/query-types.md) that determines what your Query Output looks like
 - None or one [**FROM statement**](queries/data-commands#from) to pick a specific tag or folder (or another [source](reference/sources.md)) to look at
 - None to multiple [**other Data Commands**](queries/data-commands.md) that help you filter, group and sort your wanted output
 
@@ -122,7 +122,7 @@ This'll give you back a result like:
 | The New Colossus |	Emma Lazarus | 1883	| - [[Favorite Poems]] |	
 | The Raven |	Edgar Allan Poe |	1845 | - [[Favorite Poems]] |	
 
-That's not where the capabilities of dataview end, though. You can also **perform operations** with help of [**functions**](reference/functions.md) on your values. Mind that these operations are only made inside your query - your **data in your files stays untouched**.
+That's not where the capabilities of dataview end, though. You can also **operate on your data** with help of [**functions**](reference/functions.md). Mind that these operations are only made inside your query - your **data in your files stays untouched**.
 
 ~~~markdown
 ```dataview
@@ -145,4 +145,4 @@ As you can see, dataview doesn't only allow you to aggregate your data swiftly a
 
 ## Resources and Help
 
-This documentation is not the only place that can help you out on your data journey. Take a look at [Resources and Support](./resources/resources-and-support.md) for a list of helpful pages and places.
+This documentation is not the only place that can help you out on your data journey. Take a look at [Resources and Support](./resources/resources-and-support.md) for a list of helpful pages and videos.


### PR DESCRIPTION
Hello again,

next documentation rework. I wanted to add a very comprehensive section to the Overview that gives reader the chance to jump to the pages and sections in the documentation they might be interested in - and to give newcomers a rough idea what they can accomplish with this plugin (and what not). Changes are deployed [here](https://s-blu.github.io/obsidian-dataview/)

closes #1523 closes #1522