### PR TITLE
Keep outlink metadata in the `file` meta object

### DIFF
--- a/src/data-model/markdown.ts
+++ b/src/data-model/markdown.ts
@@ -112,8 +112,10 @@ export class PageMetadata {
 
     /** Convert all links in this file to file links. */
     public fileLinks(): Link[] {
-        let distinctPaths = new Set<string>(this.links.map(l => l.path));
-        return Array.from(distinctPaths).map(l => Link.file(l));
+        // We want to make them distinct, but where links are not raw links we
+        // now keep the additional metadata.
+        let distinctLinks = new Set<Link>(this.links);
+        return Array.from(distinctLinks);
     }
 
     /** Map this metadata to a full object; uses the index for additional data lookups.  */


### PR DESCRIPTION
Previously, the links in `outLinks` did not retain any metadata about the links themselves. This PR ensures that said links retain their metadata, allowing more creative queries.

It does not add this metadata for the `inLinks` as the index does not retain this information, making it inaccessible at the required location. That is a potential future enhancement but likely requires some significant re-engineering.

Closes #1471. 