### PR TITLE
Documentation: Rework of "DQL, JS and Inlines" Page

### DIFF
--- a/docs/docs/queries/dql-js-inline.md
+++ b/docs/docs/queries/dql-js-inline.md
@@ -94,7 +94,7 @@ WHERE duration > dur("10h")
 ```
 ~~~
 
-This will give you the Example page back, even though the result doesnt fulfill the `WHERE` clause, because the value you are comparing against is no duration (yet).
+This will give you the Example page back, even though the result does'nt fulfill the `WHERE` clause, because the value you are comparing against is no duration (yet).
 
 ## Dataview JS
 
@@ -116,6 +116,9 @@ Inside of a JS dataview block, you have access to the full dataview API via the 
 what you can do with it, see the [API documentation](../../api/code-reference), or the [API
 examples](../../api/code-examples).
 
+!!! attention "Advanced usage"
+    Writing Javascript queries is a advanced technique that requires understanding in programming and JS. Please be aware that JS Queries have access to your file system and be cautious when using other peopless' JS Queries, especially when they are not publicy shared through the Obsidian Community.
+
 ## Inline Dataview JS
 
 Similar to the query language, you can write JS inline queries, which let you embed a computed JS value directly. You
@@ -127,3 +130,5 @@ create JS inline queries via inline code blocks:
 
 In inline DataviewJS, you have access to the `dv` variable, as in `dataviewjs` codeblocks, and can make all of the same calls. The result
 should be something which evaluates to a JavaScript value, which Dataview will automatically render appropriately.
+
+Unline Inline DQL queries, Inline JS queries do have access to everything a Dataview JS Query has available and can hence query and output multiple pages.

--- a/docs/docs/queries/dql-js-inline.md
+++ b/docs/docs/queries/dql-js-inline.md
@@ -1,4 +1,4 @@
-# Creating Queries
+# DQL, JS and Inlines
 
 Once you've added [useful data to relevant pages](../annotation/add-metadata.md), you'll want to actually display it somewhere or operate on it. Dataview
 allows this in four different ways, all of which are written in codeblocks directly in your Markdown and live-reloaded
@@ -6,9 +6,9 @@ when your vault changes.
 
 ## Dataview Query Language (DQL)
 
-The dataview [query language](../../queries/structure) is a simplistic, SQL-like language for quickly creating views. It
-supports basic arithmetic and comparison operations, and is good for basic applications. You create dataview queries
-using `dataview`-annotated codeblocks:
+The [**Dataview Query Language**](../../queries/structure) (for short **DQL**) is a SQL-like language and Dataviews core functionality. It supports [four Query Types](./query-types.md) to produce different outputs, [data commands](./data-commands.md) to refine, resort or group your result and [plentiful functions](../reference/functions.md) which allow numerous operations and adjustments to achieve your wanted output. 
+
+You create a **DQL** query with a codeblock that uses `dataview` as type:
 
 ~~~
 ```dataview
@@ -17,21 +17,84 @@ SORT rating DESC
 ```
 ~~~
 
-The details of how to write a query are explained in the [query language
-reference](../../queries/structure); if you learn better by example, take a look at the [query examples](../../resources/examples).
+!!! attention "Use backticks"
+    A valid codeblock needs to use backticks (\`) on start and end (three each). Do not confuse the backtick with the similar looking apostrophe ' !
+
+Find a explanation how to write a DQL Query under the [query language
+reference](../../queries/structure). If you learn better by example, take a look at the [query examples](../../resources/examples).
 
 ## Inline DQL
 
-The query language also provides inline queries, which allow you to embed single values
-directly inside a page - for example, todays date via `= date(today)`, or a field from another page via `=
-[[Page]].value`. You create inline queries using inline codeblocks:
+A Inline DQL uses a inline block format instead of a code block and a configurable prefix to mark this inline code block as a DQL block.
 
 ~~~
 `= this.file.name`
 ~~~
 
-Inline DQL expressions are written using the [query language expression language](../../reference/expressions). You can
-configure inline queries to use a different prefix (like `dv:` or `~`) in the Dataview settings.
+!!! info "Change of DQL prefix"
+    You can change the `=` to another token (like `dv:` or `~`) in Dataviews' settings under "Codeblock Settings" > "Inline Query Prefix"
+
+Inline DQL Queries display **exactly one value** somewhere in the middle of your note. They seamlessly blend into the content of your note:
+
+~~~markdown
+Today is `= date(today)` - `= [[exams]].deadline - date(today)` until exams!
+~~~
+
+would, for example, render to 
+
+~~~markdown
+Today is November 07, 2022 - 2 months, 5 days until exams!
+~~~
+
+**Inline DQL** cannot query multiple pages. They always display exactly one value, not a list (or table) of values. You can either access the properties of the **current page** via prefix `this.` or a different page via `[[linkToPage]]`.
+
+~~~markdown
+`= this.file.name`
+`= this.file.mtime`
+`= this.someMetadataField`
+`= [[secondPage]].file.name`
+`= [[secondPage]].file.mtime`
+`= [[secondPage]].someMetadataField`
+~~~
+
+You can use everything available as [expressions](../../reference/expressions) and [literals](../../reference/literals) in a Inline DQL, including [functions](../../reference/functions). Query Types and Data Commands on the other hand are **not available in Inlines.**
+
+### Using Inline DQL as metadata value
+
+You might have seen that users save Inline DQLs in a metadata field, like
+
+```markdown
+start:: 07h00m
+end:: 18h00m
+pause:: 01h30m
+duration:: `= this.end - this.start - this.pause`
+```
+
+You can list this value (9h 30m in our example) then i.e. in a TABLE without needing to repeat the calculation:
+
+~~~markdown
+```dataview
+TABLE start, end, duration
+WHERE duration
+```
+~~~
+
+Gives you
+
+| File (1)	| start| 	end| 	duration| 
+| ---- | ----- | ------ |  ----- | 
+| Example | 7 hours	| 18 hours| 	9 hours, 30 minutes | 
+
+This can be very handy, but comes with a limitation: While the value that gets displayed in the result is the calculated one, **the saved value inside the Inline DQL is still your calculation**. This means you cannot filter for the Inlines' result like:
+
+~~~markdown
+```dataview
+TABLE start, end, duration
+WHERE duration > dur("10h")
+```
+~~~
+
+This will give you the Example page back, even though the result doesnt fulfill the `WHERE` clause, because the value you are comparing against is no duration (yet).
 
 ## Dataview JS
 

--- a/docs/docs/queries/dql-js-inline.md
+++ b/docs/docs/queries/dql-js-inline.md
@@ -59,42 +59,8 @@ Today is November 07, 2022 - 2 months, 5 days until exams!
 
 You can use everything available as [expressions](../../reference/expressions) and [literals](../../reference/literals) in a Inline DQL, including [functions](../../reference/functions). Query Types and Data Commands on the other hand are **not available in Inlines.**
 
-### Using Inline DQL as metadata value
-
-You might have seen that users save Inline DQLs in a metadata field, like
-
-```markdown
-start:: 07h00m
-end:: 18h00m
-pause:: 01h30m
-duration:: `= this.end - this.start - this.pause`
-```
-
-You can list this value (9h 30m in our example) then i.e. in a TABLE without needing to repeat the calculation:
-
-~~~markdown
-```dataview
-TABLE start, end, duration
-WHERE duration
-```
-~~~
-
-Gives you
-
-| File (1)	| start| 	end| 	duration| 
-| ---- | ----- | ------ |  ----- | 
-| Example | 7 hours	| 18 hours| 	9 hours, 30 minutes | 
-
-This can be very handy, but comes with a limitation: While the value that gets displayed in the result is the calculated one, **the saved value inside the Inline DQL is still your calculation**. This means you cannot filter for the Inlines' result like:
-
-~~~markdown
-```dataview
-TABLE start, end, duration
-WHERE duration > dur("10h")
-```
-~~~
-
-This will give you the Example page back, even though the result does'nt fulfill the `WHERE` clause, because the value you are comparing against is no duration (yet).
+!!! hint "Saving Inline DQL in metadata fields"
+    You can store a Inline DQL inside a field for reusability with some limitations. Read more about it in [the FAQ](../../resources/faq#can-i-save-the-result-of-a-query-for-reusability).
 
 ## Dataview JS
 
@@ -132,3 +98,6 @@ In inline DataviewJS, you have access to the `dv` variable, as in `dataviewjs` c
 should be something which evaluates to a JavaScript value, which Dataview will automatically render appropriately.
 
 Unline Inline DQL queries, Inline JS queries do have access to everything a Dataview JS Query has available and can hence query and output multiple pages.
+
+!!! info "Change of Inline JS prefix"
+    You can change the `$=` to another token (like `dvjs:` or `$~`) in Dataviews' settings under "Codeblock Settings" > "Javascript Inline Query Prefix"

--- a/docs/docs/resources/faq.md
+++ b/docs/docs/resources/faq.md
@@ -27,3 +27,40 @@ There are two ways:
 ### Do you have a list of resources to learn from?
 
 Yes! Please see the [Resources](../resources/resources-and-support.md) page.
+
+### Can I save the result of a query for reusability?
+
+You can write reusable Javascript Queries with the [dv.view](../../api/code-reference/#dvviewpath-input) function. In DQL, beside the possibility of writing your Query inside a Template and using this template (either with the [Core Plugin Templates](https://help.obsidian.md/Plugins/Templates) or the popular Community Plugin [Templater](https://obsidian.md/plugins?id=templater-obsidian)), you can **save calculations in metadata fields via [Inline DQL](../../queries/dql-js-inline#inline-dql)**, for example:
+
+```markdown
+start:: 07h00m
+end:: 18h00m
+pause:: 01h30m
+duration:: `= this.end - this.start - this.pause`
+```
+
+You can list the value (9h 30m in our example) then i.e. in a TABLE without needing to repeat the calculation:
+
+~~~markdown
+```dataview
+TABLE start, end, duration
+WHERE duration
+```
+~~~
+
+Gives you
+
+| File (1)	| start| 	end| 	duration| 
+| ---- | ----- | ------ |  ----- | 
+| Example | 7 hours	| 18 hours| 	9 hours, 30 minutes | 
+
+**But storing a Inline DQL in a field comes with a limitation**: While the value that gets displayed in the result is the calculated one, **the saved value inside the Inline DQL is still your calculation**. This means you cannot filter for the Inlines' result like:
+
+~~~markdown
+```dataview
+TABLE start, end, duration
+WHERE duration > dur("10h")
+```
+~~~
+
+This will give you the Example page back, even though the result does'nt fulfill the `WHERE` clause, because the value you are comparing against is no duration (yet).


### PR DESCRIPTION
Hello,

smaller rework of the Codeblock-Type pages. [Deployment](https://s-blu.github.io/obsidian-dataview/queries/dql-js-inline/).

I felt unsure where to put the remark regarding the usage of a inline DQL as a field value - I saw these use cases a few times in  the Obsidian Discord. I added it to "DQL, JS and Inlines" itself, but it felt somewhat out of place there, so I moved it to the FAQ. No other place came to my mind. Any opinions about that? 

Also, I thought it is appropriate to add a little disclaimer to be careful when copy/pasting JS queries. While I have little worry about queries that are shared through forum or discord, the read/write access of these queries allow for quite some nonsense and I saw people using queries they don't understand very carefreely. If you do not agree with this, we might find a better place or way to ask for mindfullness with foreign code.