### PR TITLE
feat: add a new regextest function and deprecate regexmatch

### DIFF
--- a/docs/docs/reference/expressions.md
+++ b/docs/docs/reference/expressions.md
@@ -100,7 +100,7 @@ See the [note in the FAQ](../resources/faq.md#how-do-i-use-fields-with-the-same-
 
 Dataview supports various functions for manipulating data, which are described in full in the [functions
 documentation](../functions). They have the general syntax `function(arg1, arg2, ...)` - i.e., `lower("yes")` or
-`regexmatch("text", ".+")`.
+`regextest("text", ".+")`.
 
 ### Lambdas
 

--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -470,8 +470,8 @@ regextest("what", "what's up dog?") = true
 ### `regexmatch(pattern, string)` (DEPRECATED)
 
 Checks if the given string matches the given pattern. Note: the pattern gets a `^` 
-prepended and a `$` appended, which means it will only match if the match starts at
-the beginning and end at the end of the string. (using the JavaScript regex engine).
+prepended and a `$` appended to it, which means it will only match if the match starts at
+the beginning and ends at the end of the string. (using the JavaScript regex engine).
 
 ```
 regexmatch("\w+", "hello") = true

--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -456,14 +456,28 @@ map(["yes", "no"], (x) => x + "?") = ["yes?", "no?"]
 
 ## String Operations
 
-### `regexmatch(pattern, string)`
+### `regextest(pattern, string)`
 
 Checks if the given string matches the given pattern (using the JavaScript regex engine).
+
+```
+regextest("\w+", "hello") = true
+regextest(".", "a") = true
+regextest("yes|no", "maybe") = false
+regextest("what", "what's up dog?") = true
+```
+
+### `regexmatch(pattern, string)` (DEPRECATED)
+
+Checks if the given string matches the given pattern. Note: the pattern gets a `^` 
+prepended and a `$` appended, which means it will only match if the match starts at
+the beginning and end at the end of the string. (using the JavaScript regex engine).
 
 ```
 regexmatch("\w+", "hello") = true
 regexmatch(".", "a") = true
 regexmatch("yes|no", "maybe") = false
+regexmatch("what", "what's up dog?") = false
 ```
 
 ### `regexreplace(string, pattern, replacement)`

--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -506,7 +506,6 @@ export namespace DefaultFunctions {
 
     export const regexmatch = new FunctionBuilder("regexmatch")
         .add2("string", "string", (pattern: string, field: string) => {
-            if (!pattern.startsWith("^") && !pattern.endsWith("$")) pattern = "^" + pattern + "$";
             return !!field.match(pattern);
         })
         .add2("null", "*", (_n, _a) => false)

--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -506,6 +506,7 @@ export namespace DefaultFunctions {
 
     export const regexmatch = new FunctionBuilder("regexmatch")
         .add2("string", "string", (pattern: string, field: string) => {
+            if (!pattern.startsWith("^") && !pattern.endsWith("$")) pattern = "^" + pattern + "$";
             return !!field.match(pattern);
         })
         .add2("null", "*", (_n, _a) => false)

--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -504,6 +504,13 @@ export namespace DefaultFunctions {
         .add1("*", e => e)
         .build();
 
+    export const regextest = new FunctionBuilder("regextest")
+        .add2("string", "string", (pattern: string, field: string) => RegExp(pattern).test(field))
+        .add2("null", "*", (_n, _a) => false)
+        .add2("*", "null", (_a, _n) => false)
+        .vectorize(2, [0, 1])
+        .build();
+
     export const regexmatch = new FunctionBuilder("regexmatch")
         .add2("string", "string", (pattern: string, field: string) => {
             if (!pattern.startsWith("^") && !pattern.endsWith("$")) pattern = "^" + pattern + "$";
@@ -784,6 +791,7 @@ export const DEFAULT_FUNCTIONS: Record<string, FunctionImpl> = {
 
     // String operations.
     regexreplace: DefaultFunctions.regexreplace,
+    regextest: DefaultFunctions.regextest,
     regexmatch: DefaultFunctions.regexmatch,
     replace: DefaultFunctions.replace,
     lower: DefaultFunctions.lower,

--- a/src/test/function/aggregation.test.ts
+++ b/src/test/function/aggregation.test.ts
@@ -63,7 +63,7 @@ describe("all()", () => {
 
     test("vectorized", () => {
         expectEvals('all(regexmatch("a+", list("a", "aaaa")))', true);
-        expectEvals('all(regexmatch("a+", list("a", "aaab")))', false);
+        expectEvals('all(regexmatch("a+", list("a", "aaab")))', true);
         expectEvals('any(regexmatch("a+", list("a", "aaab")))', true);
     });
 });

--- a/src/test/function/aggregation.test.ts
+++ b/src/test/function/aggregation.test.ts
@@ -65,6 +65,10 @@ describe("all()", () => {
         expectEvals('all(regexmatch("a+", list("a", "aaaa")))', true);
         expectEvals('all(regexmatch("a+", list("a", "aaab")))', false);
         expectEvals('any(regexmatch("a+", list("a", "aaab")))', true);
+
+        expectEvals('all(regextest("a+", list("a", "aaaa")))', true);
+        expectEvals('all(regextest("a+", list("a", "aaab")))', true);
+        expectEvals('any(regextest("a+", list("a", "aaab")))', true);
     });
 });
 

--- a/src/test/function/aggregation.test.ts
+++ b/src/test/function/aggregation.test.ts
@@ -63,7 +63,7 @@ describe("all()", () => {
 
     test("vectorized", () => {
         expectEvals('all(regexmatch("a+", list("a", "aaaa")))', true);
-        expectEvals('all(regexmatch("a+", list("a", "aaab")))', true);
+        expectEvals('all(regexmatch("a+", list("a", "aaab")))', false);
         expectEvals('any(regexmatch("a+", list("a", "aaab")))', true);
     });
 });

--- a/src/test/function/string.test.ts
+++ b/src/test/function/string.test.ts
@@ -20,6 +20,19 @@ describe("containsword()", () => {
     test("case insensitive 2", () => expect(parseEval('containsword("Hello there, chap!", "HELLO")')).toEqual(true));
 });
 
+// <-- regextest() -->
+
+describe("regextest()", () => {
+    test(".+", () => expect(parseEval('regextest(".+", "stuff")')).toEqual(true));
+    test(".+ empty", () => expect(parseEval('regextest(".+", "")')).toEqual(false));
+    test(".* empty", () => expect(parseEval('regextest(".*", "")')).toEqual(true));
+    test("word", () => expect(parseEval('regextest("\\w+", "m3me")')).toEqual(true));
+    test("whitespace", () => expect(parseEval('regextest("\\s+", "  ")')).toEqual(true));
+    test("exact", () => expect(parseEval('regextest("what", "what")')).toEqual(true));
+    test("not exact", () => expect(parseEval('regextest("what", "what are you doing?")')).toEqual(true));
+    test("start & end", () => expect(parseEval('regextest("^what$", "what")')).toEqual(true));
+});
+
 // <-- regexmatch() -->
 
 describe("regexmatch()", () => {

--- a/src/test/function/string.test.ts
+++ b/src/test/function/string.test.ts
@@ -29,8 +29,6 @@ describe("regexmatch()", () => {
     test("word", () => expect(parseEval('regexmatch("\\w+", "m3me")')).toEqual(true));
     test("whitespace", () => expect(parseEval('regexmatch("\\s+", "  ")')).toEqual(true));
     test("exact", () => expect(parseEval('regexmatch("what", "what")')).toEqual(true));
-    test("not exact", () => expect(parseEval('regexmatch("what", "what are you doing?")')).toEqual(true));
-    test("start & end", () => expect(parseEval('regexmatch("^what$", "what")')).toEqual(true));
 });
 
 // <-- replace() -- >

--- a/src/test/function/string.test.ts
+++ b/src/test/function/string.test.ts
@@ -29,6 +29,8 @@ describe("regexmatch()", () => {
     test("word", () => expect(parseEval('regexmatch("\\w+", "m3me")')).toEqual(true));
     test("whitespace", () => expect(parseEval('regexmatch("\\s+", "  ")')).toEqual(true));
     test("exact", () => expect(parseEval('regexmatch("what", "what")')).toEqual(true));
+    test("not exact", () => expect(parseEval('regexmatch("what", "what are you doing?")')).toEqual(true));
+    test("start & end", () => expect(parseEval('regexmatch("^what$", "what")')).toEqual(true));
 });
 
 // <-- replace() -- >


### PR DESCRIPTION
## Motivation

The `regexmatch` function only matches exact strings because it adds the `^` and `$` special characters to **every** pattern.

This results in the following test failing:

```js
test("not exact", () => expect(parseEval('regexmatch("what", "what are you doing?")')).toEqual(true));
```

## Solution

<details>
<summary>First solution</summary>

Stop adding the delimiters (`^` and `$`) to every pattern:

```typescript
 export const regexmatch = new FunctionBuilder("regexmatch")
        .add2("string", "string", (pattern: string, field: string) => {
            if (!pattern.startsWith("^") && !pattern.endsWith("$")) pattern = "^" + pattern + "$";
//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            return !!field.match(pattern);
        })
```

</details>

Added a new function called `regextest` that matches javascript's [test](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) function.

Also, deprecated `regexmatch` to prepare for a major-version-change removal and update the docs to make clear what the function does.

## Considerations

~This is probably a breaking change since people might be expecting to have the incorrect behavior, but I think a patch is ok.~

##### Cheers

This is an awesome plugin! Happy to contribute more to it.