### PR TITLE
Fix:#1502 Fit tag parsing to its on Obsidian.

### DIFF
--- a/src/expression/parse.ts
+++ b/src/expression/parse.ts
@@ -257,7 +257,7 @@ export const EXPRESSION = P.createLanguage<ExpressionLanguage>({
     tag: _ =>
         P.seqMap(
             P.string("#"),
-            P.alt(P.regexp(/[\p{Letter}0-9_/-]/u).desc("text"), P.regexp(EMOJI_REGEX).desc("text")).many(),
+            P.alt(P.regexp(/[^\u2000-\u206F\u2E00-\u2E7F'!"#$%&()*+,.:;<=>?@^`{|}~\[\]\\\s]/).desc("text")).many(),
             (start, rest) => start + rest.join("")
         ).desc("tag ('#hello/stuff')"),
 


### PR DESCRIPTION
Thank you for the brilliant plugin!

To fix #1502, I thought that the parsing of tags could be adapted to Obsidian's behaviour.
I am new to this plugin so perhaps I have some misunderstanding of the design. If so, please point anything out to me.