### PR TITLE
Make DataviewJS keyword configurable in settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ export default class DataviewPlugin extends Plugin {
         );
 
         // DataviewJS codeblocks.
-        this.registerPriorityCodeblockPostProcessor("dataviewjs", -100, async (source: string, el, ctx) =>
+        this.registerPriorityCodeblockPostProcessor(this.settings.dataviewJsKeyword, -100, async (source: string, el, ctx) =>
             this.dataviewjs(source, el, ctx, ctx.sourcePath)
         );
 
@@ -297,6 +297,19 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         this.containerEl.createEl("h2", { text: "Codeblock Settings" });
+
+        new Setting(this.containerEl)
+            .setName("DataviewJS Keyword")
+            .setDesc("Keyword for DataviewJS blocks. Defaults to 'dataviewjs'. Reload required for changes to take effect.")
+            .addText(text =>
+                text
+                    .setPlaceholder("dataviewjs")
+                    .setValue(this.plugin.settings.dataviewJsKeyword)
+                    .onChange(async value => {
+                        if (value.length == 0) return;
+                        await this.plugin.updateSettings({ dataviewJsKeyword: value });
+                    })
+            );
 
         new Setting(this.containerEl)
             .setName("Inline Query Prefix")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -86,6 +86,8 @@ export interface DataviewSettings extends QuerySettings, ExportSettings {
     enableInlineDataviewJs: boolean;
     /** Enable or disable rendering inline fields prettily. */
     prettyRenderInlineFields: boolean;
+    /** The keyword for DataviewJS blocks. */
+    dataviewJsKeyword: string;
 }
 
 /** Default settings for dataview on install. */
@@ -100,5 +102,6 @@ export const DEFAULT_SETTINGS: DataviewSettings = {
         enableDataviewJs: false,
         enableInlineDataviewJs: false,
         prettyRenderInlineFields: true,
+        dataviewJsKeyword: "dataviewjs",
     },
 };


### PR DESCRIPTION
Making the keyword for DataviewJS blocks configurable in order to mitigate the risk of a DataviewJS block injection attack.

For context, see [this comment](https://github.com/blacksmithgu/obsidian-dataview/issues/615#issuecomment-1254572499) on #615. Relevant portions:

> It's pretty trivial to create HTML that displays some completely normal-looking text, but on copy, copies a malicious script that is wrapped in a dataviewjs block to the user's clipboard. If an unsuspecting user were to copy that seemingly innocuous text and then paste it into their Obsidian vault, if they have DataviewJS enabled, the malicious code would execute.

> One simple mitigation for the specific issue mentioned above is to allow users to customize the keyword used to begin a dataviewjs block.

Note that this requires an app reload on change. I tried doing it without a reload but I couldn't figure out how to unregister a previously registered MarkdownPostProcessor.

Please let me know if there's anything I should change. Thanks!