### PR TITLE
fix(documentation build): Use mkdocs-material v8

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,6 @@ jobs:
         with:
           python-version: 3.x
       - run: |
-          pip install mkdocs-material mkdocs-redirects
+          pip install mkdocs-material==8.5.11  mkdocs-redirects
           cd docs
           mkdocs gh-deploy --force


### PR DESCRIPTION
The build is failing to the new v9 of mkdocs-material. Theres an open issue about that [here](https://github.com/squidfunk/mkdocs-material/issues/4824), but non of the given reproductions seem to be the cause on our side.
I was not able to fix the problem and prevent material v9 from crashing. 

Using the latest 8 version fixed it for me, so this might be a way to go temporarily.