### PR TITLE
fix: calendar can appear twice

### DIFF
--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -433,7 +433,6 @@ export class DataviewApi {
                 break;
         }
         childComponent.load();
-        childComponent.onload();
     }
 
     /**


### PR DESCRIPTION
Fix an issue where the calendar can appear twice by removing an extra onload() call. Calling addChild() already causes an onload() to trigger.

This has no effect on the rendering of task, list, or table components, which continue to render correctly (once, and not duplicated like the calendar).

Fix blacksmithgu/obsidian-dataview#1773.