### PR TITLE
Feature: customizable no result messages (#1843)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-dataview",
-  "version": "0.5.54",
+  "version": "0.5.55",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-dataview",
-      "version": "0.5.54",
+      "version": "0.5.55",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "https://github.com/lishid/cm-language",
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.0",
-        "@rollup/plugin-node-resolve": "^13.1.3",
+        "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-typescript": "^8.3.0",
         "@types/jest": "^27.0.1",
         "@types/luxon": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.0",
-    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/jest": "^27.0.1",
     "@types/luxon": "^3.2.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -376,6 +376,21 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
+            .setName("Message to Display on Empty Result")
+            .setDesc("This is the message to display if rendering a warning about 0 results.")
+            .addText(text =>
+                text
+                    .setPlaceholder(DEFAULT_QUERY_SETTINGS.onEmptyResultMessage)
+                    .setValue(this.plugin.settings.onEmptyResultMessage)
+                    .onChange(async value => {
+                        let message = value.trim();
+                        if (message.length == 0) message = DEFAULT_QUERY_SETTINGS.onEmptyResultMessage;
+                        await this.plugin.updateSettings({ onEmptyResultMessage: message });
+                        this.plugin.index.touch();
+                    })
+                );
+
+        new Setting(this.containerEl)
             .setName("Render Null As")
             .setDesc("What null/non-existent should show up as in tables, by default. This supports Markdown notation.")
             .addText(text =>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,8 @@ export interface QuerySettings {
     recursiveSubTaskCompletion: boolean;
     /** If true, render a modal which shows no results were returned. */
     warnOnEmptyResult: boolean;
+    /** The default message for when there are no results */
+    onEmptyResultMessage: string;
     /** Whether or not automatic view refreshing is enabled. */
     refreshEnabled: boolean;
     /** The interval that views are refreshed, by default. */
@@ -43,6 +45,7 @@ export const DEFAULT_QUERY_SETTINGS: QuerySettings = {
     taskCompletionDateFormat: "yyyy-MM-dd",
     recursiveSubTaskCompletion: false,
     warnOnEmptyResult: true,
+    onEmptyResultMessage: "Dataview: No results for the query.",
     refreshEnabled: true,
     refreshInterval: 2500,
     defaultDateFormat: "MMMM dd, yyyy",

--- a/src/ui/views/calendar-view.ts
+++ b/src/ui/views/calendar-view.ts
@@ -38,7 +38,7 @@ export class DataviewCalendarRenderer extends DataviewRefreshableRenderer {
             renderErrorPre(this.container, "Dataview: " + maybeResult.error);
             return;
         } else if (maybeResult.value.data.length == 0 && this.settings.warnOnEmptyResult) {
-            renderErrorPre(this.container, "Dataview: Query returned 0 results.");
+            renderErrorPre(this.container, this.settings.onEmptyResultMessage);
             return;
         }
         let dateMap = new Map<string, CalendarFile[]>();

--- a/src/ui/views/list-view.tsx
+++ b/src/ui/views/list-view.tsx
@@ -67,7 +67,7 @@ export function ListView({ query, sourcePath }: { query: Query; sourcePath: stri
         );
 
     if (items.items.length == 0 && context.settings.warnOnEmptyResult)
-        return <ErrorMessage message="Dataview: No results to show for list query." />;
+        return <ErrorMessage message={context.settings.onEmptyResultMessage} />;
 
     return <ListGrouping items={items.items} sourcePath={sourcePath} />;
 }

--- a/src/ui/views/table-view.tsx
+++ b/src/ui/views/table-view.tsx
@@ -60,7 +60,7 @@ export function TableGrouping({
                 </tbody>
             </table>
             {settings.warnOnEmptyResult && values.length == 0 && (
-                <ErrorMessage message="Dataview: No results to show for table query." />
+                <ErrorMessage message={settings.onEmptyResultMessage} />
             )}
         </Fragment>
     );

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -151,7 +151,7 @@ function ListItem({ item }: { item: SListEntry }) {
 function TaskList({ items }: { items: SListItem[] }) {
     const settings = useContext(DataviewContext).settings;
     if (items.length == 0 && settings.warnOnEmptyResult)
-        return <ErrorMessage message="Dataview: No results to show for task query." />;
+        return <ErrorMessage message={settings.onEmptyResultMessage} />;
 
     let [nest, _mask] = nestItems(items);
     return (


### PR DESCRIPTION
This PR let's the user specify a custom "no results" message - from feature request #1843. 

<img width="598" alt="Screenshot 2023-03-22 at 9 47 16 AM" src="https://user-images.githubusercontent.com/54643/227019547-aac29de1-aa80-442f-8cf6-f1c9d26a337c.png">

Some considerations:

- previous "no result" messages were context specific, they communicated whether it was a table, list, or task query. This normalizes everything to a single generic message, which could be considered a step backward. I'm happy to reintroduce context into the default messaging if desired.
- For some reason, `plugin-node-resolve` had to be manually installed for `npm run dev` to work - which updated the version in `package.json.` If that should be reverted just let me know.
- For some UI settings, their description and visibility change when the parent toggle is on or off. See [Emoji Shorthand](https://github.com/blacksmithgu/obsidian-dataview/blob/master/src/main.ts#L525) for example. I was on the fence on whether it would be necessary, and it adds more code so I wanted to get your feedback first.

This is my first time with node/typescript, so let me know if I missed anything!

Cheers!