### PR TITLE
Feature date extensions

### DIFF
--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -62,6 +62,16 @@ date("2020-04-18") = <date object representing April 18th, 2020>
 date([[2021-04-16]]) = <date object for the given page, refering to file.day>
 ```
 
+### `date(text, format)`
+
+Parses a date from text to luxon `DateTime` with the specified format. Note localised formats might not work. 
+Uses [Luxon tokens](https://moment.github.io/luxon/#/formatting?id=table-of-tokens).
+
+```js
+date("12/31/2022", "MM/dd/yyyy") => DateTime for Decemeber 31th, 2022
+date("210331", "yyMMdd") => DateTime for March 13th, 2023
+```
+
 ### `dur(any)`
 
 Parses a duration from the provided string or duration, returning null on failure.

--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -69,7 +69,8 @@ Uses [Luxon tokens](https://moment.github.io/luxon/#/formatting?id=table-of-toke
 
 ```js
 date("12/31/2022", "MM/dd/yyyy") => DateTime for Decemeber 31th, 2022
-date("210331", "yyMMdd") => DateTime for March 13th, 2023
+date("210313", "yyMMdd") => DateTime for March 13th, 2021
+date("946778645000", "x") => DateTime for "2000-01-02T03:04:05"
 ```
 
 ### `dur(any)`

--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -276,6 +276,14 @@ export namespace DefaultFunctions {
 
             return null;
         })
+        .add2("string", "string", (d, f) => {
+            let parsedDate = DateTime.fromFormat(d, f)
+ 
+            if (parsedDate.isValid) return parsedDate
+            else { throw Error(`Can't handle format (${ f }) on date string (${ d })`) }
+
+            return null;
+        })
         .add1("null", () => null)
         .vectorize(1, [0])
         .build();

--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -277,10 +277,17 @@ export namespace DefaultFunctions {
             return null;
         })
         .add2("string", "string", (d, f) => {
-            let parsedDate = DateTime.fromFormat(d, f)
- 
-            if (parsedDate.isValid) return parsedDate
-            else { throw Error(`Can't handle format (${ f }) on date string (${ d })`) }
+            if (f === "x" || f==="X") {
+                let match = NUMBER_REGEX.exec(d)
+                if (match) return DateTime.fromMillis(Number.parseInt(match[0]) * ( f==="X" ? 1000 : 1))
+                else {
+                    throw Error("Not a number for format( (${ f }): ${ d }")
+                }
+            } else {
+                let parsedDate = DateTime.fromFormat(d, f)
+                if (parsedDate.isValid) return parsedDate
+                else { throw Error(`Can't handle format (${ f }) on date string (${ d })`) }    
+            } 
 
             return null;
         })

--- a/src/test/function/coerce.test.ts
+++ b/src/test/function/coerce.test.ts
@@ -16,6 +16,8 @@ describe("string()", () => {
 test("date()", () => {
     expect(parseEval("date([[2020-04-18]])")).toEqual(DateTime.fromObject({ year: 2020, month: 4, day: 18 }));
     expect(parseEval("date([[Place|2021-04]])")).toEqual(DateTime.fromObject({ year: 2021, month: 4, day: 1 }));
+    expect(parseEval('date("12/31/2022", "MM/dd/yyyy")')).toEqual(DateTime.fromObject({ year: 2022, month: 12, day: 31 }));
+    expect(parseEval('date("210331", "yyMMdd")')).toEqual(DateTime.fromObject({ year: 2022, month: 3, day: 12 }));   
 });
 
 test("list()", () => {

--- a/src/test/function/coerce.test.ts
+++ b/src/test/function/coerce.test.ts
@@ -17,7 +17,7 @@ test("date()", () => {
     expect(parseEval("date([[2020-04-18]])")).toEqual(DateTime.fromObject({ year: 2020, month: 4, day: 18 }));
     expect(parseEval("date([[Place|2021-04]])")).toEqual(DateTime.fromObject({ year: 2021, month: 4, day: 1 }));
     expect(parseEval('date("12/31/2022", "MM/dd/yyyy")')).toEqual(DateTime.fromObject({ year: 2022, month: 12, day: 31 }));
-    expect(parseEval('date("210331", "yyMMdd")')).toEqual(DateTime.fromObject({ year: 2022, month: 3, day: 12 }));   
+    expect(parseEval('date("210313", "yyMMdd")')).toEqual(DateTime.fromObject({ year: 2021, month: 3, day: 13 }));   
 });
 
 test("list()", () => {

--- a/src/test/function/coerce.test.ts
+++ b/src/test/function/coerce.test.ts
@@ -13,13 +13,6 @@ describe("string()", () => {
     test("number", () => expect(parseEval(`string(18)`)).toEqual("18"));
 });
 
-test("date()", () => {
-    expect(parseEval("date([[2020-04-18]])")).toEqual(DateTime.fromObject({ year: 2020, month: 4, day: 18 }));
-    expect(parseEval("date([[Place|2021-04]])")).toEqual(DateTime.fromObject({ year: 2021, month: 4, day: 1 }));
-    expect(parseEval('date("12/31/2022", "MM/dd/yyyy")')).toEqual(DateTime.fromObject({ year: 2022, month: 12, day: 31 }));
-    expect(parseEval('date("210313", "yyMMdd")')).toEqual(DateTime.fromObject({ year: 2021, month: 3, day: 13 }));   
-});
-
 test("list()", () => {
     expectEvals("list(1, 2, 3)", [1, 2, 3]);
     expectEvals("list()", []);

--- a/src/test/function/functions.test.ts
+++ b/src/test/function/functions.test.ts
@@ -1,6 +1,7 @@
 // <-- Functions -->
 // <-- Function vectorization -->
 
+import { DateTime } from "luxon";
 import { DefaultFunctions } from "expression/functions";
 import { parseEval, simpleContext } from "test/common";
 
@@ -111,4 +112,15 @@ test("Evaluate 2 field extract()", () => {
 test("Evaluate nonnull()", () => {
     expect(DefaultFunctions.nonnull(simpleContext(), null, null, 1)).toEqual([1]);
     expect(DefaultFunctions.nonnull(simpleContext(), "yes")).toEqual(["yes"]);
+});
+
+// <-- date() -->
+
+test("Evaluate date()", () => {
+    expect(parseEval("date([[2020-04-18]])")).toEqual(DateTime.fromObject({ year: 2020, month: 4, day: 18 }));
+    expect(parseEval("date([[Place|2021-04]])")).toEqual(DateTime.fromObject({ year: 2021, month: 4, day: 1 }));
+    expect(parseEval('date("12/31/2022", "MM/dd/yyyy")')).toEqual(DateTime.fromObject({ year: 2022, month: 12, day: 31 }));
+    expect(parseEval('date("210313", "yyMMdd")')).toEqual(DateTime.fromObject({ year: 2021, month: 3, day: 13 }));
+    expect(parseEval('date("946778645012","x")')).toEqual(DateTime.fromMillis(946778645012)) 
+    expect(parseEval('date("946778645000","X")')).toEqual(DateTime.fromMillis(946778645000)) 
 });


### PR DESCRIPTION
Adds an option to parse dates from a text with a given format.

I've extended the date() function with a second option where one can specify text and format, which then allows for a random text to be parsed as a date using the specified format. This will allow for more custom date formats to be used in fields, and still be able to be queried as dates or redisplayed as other formats.

I've also added a few tests, and changed the documentation to match the new functionality.

There is a small caveat which is related to how DateTime.fromFormat() works, and that is that some of the localised formats can't be parsed properly. I do however still think that this would be a useful addition for a lot of cases when handling custom date formats.

I'm considering whether I should also add a `date(year, month, day, hour, minute, second)` variant, as well. Is that a good idea?