### PR TITLE
Add `flat()` to allow for reducing array depths

### DIFF
--- a/docs/docs/queries/data-commands.md
+++ b/docs/docs/queries/data-commands.md
@@ -71,7 +71,7 @@ GROUP BY (computed_field) AS name
 ```
 
 In order to make working with the `rows` array easier, Dataview supports field "swizzling". If you want the field `test` from every object in the `rows` array, then `rows.test` will automatically fetch the `test` field from every object in `rows`, yielding a new array.
-You can then apply aggregation operators like `sum()` over the resulting array.
+You can then apply aggregation operators like `sum()` or `flat()` over the resulting array.
 
 ## FLATTEN
 

--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -466,8 +466,9 @@ map(["yes", "no"], (x) => x + "?") = ["yes?", "no?"]
 
 ### `flat(array, [depth])`
 
-The `flat()` concatenates levels of the array to the desired depth. Default is 1 level, but it can
-concatenate multiple levels. This can be used to reduce array depth on `rows` after doing `GROUP BY`.
+Concatenates sub-levels of the array to the desired depth. Default is 1 level, but it can
+concatenate multiple levels. E.g. Can be used to reduce array depth on `rows` lists after
+doing `GROUP BY`.
 
 ```js
 flat(list(1, 2, 3, list(4, 5), 6)) => list(1, 2, 3, 4, 5, 6)

--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -464,6 +464,17 @@ map([1, 2, 3], (x) => x + 2) = [3, 4, 5]
 map(["yes", "no"], (x) => x + "?") = ["yes?", "no?"]
 ```
 
+### `flat(array, [depth])`
+
+The `flat()` concatenates levels of the array to the desired depth. Default is 1 level, but it can
+concatenate multiple levels. This can be used to reduce array depth on `rows` after doing `GROUP BY`.
+
+```js
+flat(list(1, 2, 3, list(4, 5), 6)) => list(1, 2, 3, 4, 5, 6)
+flat(list(1, list(21, 22), list(list (311, 312, 313))), 4) => list(1, 21, 22, 311, 312, 313)
+flat(rows.file.outlinks)) => All the file outlinks at first level in output
+```
+
 ---
 
 ## String Operations

--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -763,6 +763,18 @@ export namespace DefaultFunctions {
             type: link.type,
         }))
         .build();
+
+    // Concatenates sub-array elements into a new array
+    export const flat = new FunctionBuilder("flat")
+    .add1("array", a => {
+        return a.flat()
+    })
+    .add2("array", "number", (a, n) => {
+        // @ts-ignore
+        return a.flat(n)
+    })
+    .add1("null", () => null)
+    .build();
 }
 
 /** Default function implementations for the expression evaluator. */
@@ -815,6 +827,7 @@ export const DEFAULT_FUNCTIONS: Record<string, FunctionImpl> = {
     containsword: DefaultFunctions.containsword,
     reverse: DefaultFunctions.reverse,
     sort: DefaultFunctions.sort,
+    flat: DefaultFunctions.flat,
 
     // Aggregation operations like reduce.
     reduce: DefaultFunctions.reduce,

--- a/src/test/function/functions.test.ts
+++ b/src/test/function/functions.test.ts
@@ -58,6 +58,14 @@ test("Evaluate reverse(list)", () => {
     expect(parseEval('reverse(list("a", "b", "c"))')).toEqual(parseEval('list("c", "b", "a")'));
 });
 
+// <-- flat() -->
+
+test("Evaluate flat()", () => {
+    expect(parseEval("flat(list(1, 2, 3, list(11, 12)))")).toEqual(parseEval("list(1,2,3,11,12)"));
+    expect(parseEval("flat(list(1, list(21, list(221, 222)), 3, list(11, 12)))")).toEqual(parseEval("list(1,21,list(221,222),3,11,12)")); // flat(...)
+    expect(parseEval("flat(list(1, list(2, list(3, list(4, list(5))))), 3)")).toEqual(parseEval("list(1,2,3,4,list(5))")); // flat(..., 3)
+    expect(parseEval("flat(list(1, list(2, list(3, list(4, list(5))))), 10)")).toEqual(parseEval("list(1,2,3,4,5)")); // flat(..., 10)
+})
 // <-- sort() -->
 
 describe("sort()", () => {


### PR DESCRIPTION
Every now and then, like when doing `GROUP BY`, you get an extra level of the arrays, which makes it hard to do other functions like `filter()` or `sum()` & co. In addition the output in tables get an extra indentation level. If you see this happening, then this new function `flat()` can reduce that array depth through concatenating one or more levels of the array it operates upon.

Two versions exists, one with no _depth_ parameter, which defaults to one level, and one where you can specify how many levels you want to reduce.

Tests and docs are also extended.