### PR TITLE
Convert jsDate to DateTime in parseFrontMatter

### DIFF
--- a/src/data-import/markdown-file.ts
+++ b/src/data-import/markdown-file.ts
@@ -327,6 +327,9 @@ export function parseFrontmatter(value: any): Literal {
             }
 
             return result;
+        } else if (value instanceof Date) {
+            let dateParse = DateTime.fromJSDate(value)
+            return dateParse;
         } else {
             let object = value as Record<string, any>;
             let result: Record<string, Literal> = {};


### PR DESCRIPTION
Fixes #1870

In some cases, such as parsing CSVs via PapaParse, the date objects are returned as internal JS-type Date objects.  This checks for that and converts them to the DateTime objects if appropriate.
