### PR TITLE
fix: use component; improve performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-dataview",
-  "version": "0.5.54",
+  "version": "0.5.55",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-dataview",
-      "version": "0.5.54",
+      "version": "0.5.55",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "https://github.com/lishid/cm-language",
@@ -32,7 +32,7 @@
         "@zerollup/ts-transform-paths": "^1.7.18",
         "compare-versions": "^4.1.1",
         "jest": "^27.1.0",
-        "obsidian": "^0.15.4",
+        "obsidian": "^1.2.8",
         "prettier": "2.3.2",
         "rollup": "^2.67.2",
         "rollup-jest": "^1.1.3",
@@ -5568,8 +5568,8 @@
       "dev": true
     },
     "node_modules/obsidian": {
-      "version": "0.15.9",
-      "resolved": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#ff121cd409350d3afe39b08420f468d8aaee925e",
+      "version": "1.2.8",
+      "resolved": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#583ba39e3f6c0546de5e5e8742256a60e2d78ebc",
       "license": "MIT",
       "dependencies": {
         "@types/codemirror": "0.0.108",
@@ -11373,8 +11373,8 @@
       "dev": true
     },
     "obsidian": {
-      "version": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#ff121cd409350d3afe39b08420f468d8aaee925e",
-      "from": "obsidian@^0.15.4",
+      "version": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#583ba39e3f6c0546de5e5e8742256a60e2d78ebc",
+      "from": "obsidian@^1.2.8",
       "requires": {
         "@types/codemirror": "0.0.108",
         "moment": "2.29.4"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@zerollup/ts-transform-paths": "^1.7.18",
     "compare-versions": "^4.1.1",
     "jest": "^27.1.0",
-    "obsidian": "^0.15.4",
+    "obsidian": "^1.2.8",
     "prettier": "2.3.2",
     "rollup": "^2.67.2",
     "rollup-jest": "^1.1.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,8 +86,10 @@ export default class DataviewPlugin extends Plugin {
         });
 
         // editor extension for inline queries
-        this.cmExtension = [inlinePlugin(this.app, this.index, this.settings, this.api)];
-        this.registerEditorExtension(this.cmExtension);
+        if (this.settings.enableInlineDataview || this.settings.enableInlineDataviewJs) {
+            this.cmExtension = [inlinePlugin(this.app, this.index, this.settings, this.api)];
+            this.registerEditorExtension(this.cmExtension);
+        }
 
         // Dataview "force refresh" operation.
         this.addCommand({

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,7 +86,7 @@ export default class DataviewPlugin extends Plugin {
         });
 
         // editor extension for inline queries
-        this.cmExtension = [inlinePlugin(this.index, this.settings, this.api)];
+        this.cmExtension = [inlinePlugin(this.app, this.index, this.settings, this.api)];
         this.registerEditorExtension(this.cmExtension);
 
         // Dataview "force refresh" operation.

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -32,7 +32,7 @@ import { EditorSelection, Range } from "@codemirror/state";
 import { syntaxTree, tokenClassNodeProp } from "@codemirror/language";
 import { DataviewSettings } from "../settings";
 import { FullIndex } from "../data-index";
-import { App, Component, editorEditorField, editorLivePreviewField, editorViewField, TFile } from "obsidian";
+import { App, Component, editorInfoField, editorLivePreviewField, TFile } from "obsidian";
 import { DataviewApi } from "../api/plugin-api";
 import { tryOrPropogate } from "../util/normalize";
 import { parseField } from "../expression/parse";
@@ -98,9 +98,10 @@ class InlineWidget extends WidgetType {
             if ((event as MouseEvent).shiftKey) {
                 // Set the cursor after the element so that it doesn't select starting from the last cursor position.
                 if (currentPos) {
-                    //@ts-ignore
-                    const { editor } = this.view.state.field(editorEditorField).state.field(editorViewField);
-                    editor.setCursor(editor.offsetToPos(currentPos));
+                    const { editor } = this.view.state.field(editorInfoField);
+                    if (editor) {
+                        editor.setCursor(editor.offsetToPos(currentPos));
+                    }
                 }
                 return false;
             }

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -150,10 +150,6 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                 }
                 if (update.selectionSet) {
                     this.updateTree(update.view);
-                }
-                if (update.docChanged) {
-                    this.decorations = this.decorations.map(update.changes);
-                    return;
                 } else if (update.viewportChanged /*|| update.selectionSet*/) {
                     this.decorations = this.inlineRender(update.view) ?? Decoration.none;
                 }

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -148,7 +148,10 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                     this.decorations = Decoration.none;
                     return;
                 }
-                if (update.selectionSet) {
+                if (update.docChanged) {
+                    this.decorations = this.decorations.map(update.changes);
+                    this.updateTree(update.view);
+                } else if (update.selectionSet) {
                     this.updateTree(update.view);
                 } else if (update.viewportChanged /*|| update.selectionSet*/) {
                     this.decorations = this.inlineRender(update.view) ?? Decoration.none;

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -109,21 +109,21 @@ class InlineWidget extends WidgetType {
     }
 }
 
-function getCssClasses(nodeName: string): string[] {
+function getCssClasses(props: Set<string>): string[] {
     const classes: string[] = [];
-    if (nodeName.includes("strong")) {
+    if (props.has("strong")) {
         classes.push("cm-strong");
     }
-    if (nodeName.includes("em")) {
+    if (props.has("em")) {
         classes.push("cm-em");
     }
-    if (nodeName.includes("highlight")) {
+    if (props.has("highlight")) {
         classes.push("cm-highlight");
     }
-    if (nodeName.includes("strikethrough")) {
+    if (props.has("strikethrough")) {
         classes.push("cm-strikethrough");
     }
-    if (nodeName.includes("comment")) {
+    if (props.has("comment")) {
         classes.push("cm-comment");
     }
     return classes;
@@ -346,7 +346,9 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                     return;
                 }
 
-                const classes = getCssClasses(type.name);
+                const tokenProps = type.prop<String>(tokenClassNodeProp);
+                const props = new Set(tokenProps?.split(" "));
+                const classes = getCssClasses(props);
 
                 return Decoration.replace({
                     widget: new InlineWidget(classes, code, el, view),

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -198,9 +198,7 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                     const newDeco = this.renderWidget(node, view, currentFile)?.value;
                     if (newDeco) {
                         this.decorations = this.decorations.update({
-                            filterFrom: from,
-                            filterTo: to,
-                            /*filter: (from, to, newDeco) => true, */ add: [{ from: from, to: to, value: newDeco }],
+                            add: [{ from: from, to: to, value: newDeco }],
                         });
                     }
                 }


### PR DESCRIPTION
- This PR implements using `Component`. As of Obsidian 1.3.0 (currently in insider testing), using `null` throws an error.
- This PR implements partial updating of only the queries that changed, so this should improve performance a lot. This was a rather big change, I hope that I did not overlook any edge cases. 
- This closes #1915.
- This closes #1493.
- It updates Obsidian to the latest API version. The only change I did for it was using `editorInfoField`, which has been available since `0.16`, see [`editorInfoField`](https://github.com/obsidianmd/obsidian-api/blame/583ba39e3f6c0546de5e5e8742256a60e2d78ebc/obsidian.d.ts#L970).
- LP now respects the toggle that inline queries should not be rendered (before, it just applied for JS queries. If both are disabled, the Editor extension will not even load.

I'm still gathering feedback for the latest build in #dataview. 

