### PR TITLE
Update StarredCache to work with the bookmarks core plugin

### DIFF
--- a/docs/docs/annotation/metadata-pages.md
+++ b/docs/docs/annotation/metadata-pages.md
@@ -27,7 +27,7 @@ Dataview automatically adds a large amount of metadata to each page. These impli
 | `file.lists` | List | A list of all list elements in the file (including tasks); these elements are effectively tasks and can be rendered in task views. |
 | `file.frontmatter` | List | Contains the raw values of all frontmatter in form of `key | value` text values; mainly useful for checking raw frontmatter values or for dynamically listing frontmatter keys. |
 | `file.day` | Date | Only available if the file has a date inside its file name (of form `yyyy-mm-dd` or `yyyymmdd`), or has a `Date` field/inline field. |
-| `file.starred` | Boolean | if this file has been starred via the Obsidian Core Plugin "Starred Files". |
+| `file.starred` | Boolean | If this file has been bookmarked via the Obsidian Core Plugin "Bookmarks". |
 
 ## Example page
 


### PR DESCRIPTION
Resolves #1904 by making `file.starred` pull from the bookmarks core plugin instead of the deprecated stars core plugin. This simply provides a drop in replacement, treating bookmarks in bookmark groups in the same way as bookmarks at the top-level. It also keeps the `file.starred` name so as to provide backwards compatability with existing queries. I think this provides a necessary fix until/unless more detailed support for the bookmarks core plugin can be implemented.

Please let me know if you have any issues with the way I've implemented this or anything of that nature.