### PR TITLE
fix(style): set row bg on hover properly

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -23,7 +23,7 @@
 }
 
 .table-view-table > tbody > tr:hover {
-    background-color: var(--text-selection) !important;
+    background-color: var(--table-row-background-hover);
 }
 
 .table-view-table > thead > tr > th {


### PR DESCRIPTION
Closes #1426 
With catppuccin theme:
Before:
![Screenshot from 2023-07-09 19-51-22](https://github.com/blacksmithgu/obsidian-dataview/assets/66242799/d6697f71-0ba4-403f-9811-b410cbeec9ad)
After:
![Screenshot from 2023-07-09 19-51-47](https://github.com/blacksmithgu/obsidian-dataview/assets/66242799/92a921d0-912c-4a2f-9df1-7b05fc426a0f)
With a theme that sets the variable correctly, it still works fine (nord):
![Screenshot from 2023-07-09 19-50-43](https://github.com/blacksmithgu/obsidian-dataview/assets/66242799/b1705a16-2879-4859-a59c-997131267df3)
