### PR TITLE
fix typos and spelling errors

### DIFF
--- a/docs/docs/annotation/add-metadata.md
+++ b/docs/docs/annotation/add-metadata.md
@@ -106,7 +106,7 @@ Like you can see in the table, if you are using **spaces or capitalized letters*
 
 **Keys with spaces** cannot be used in a query as-is. You have two possibilities here: Either use the sanitized name, that is always all lowercase and with dashes instead of spaces or use the **row** variable syntax. Find out more [in the FAQ](../resources/faq.md).
 
-**Keys with capitalized letters** can be used as-is, if you wish. The sanitized version allows you to query for a key independent of its capitalization and makes it easier to use: You can query the same field thats, for example, in one file named `someMetadata` and in another `someMetaData` when using the sanitized key `somemetadata`. 
+**Keys with capitalized letters** can be used as-is, if you wish. The sanitized version allows you to query for a key independent of its capitalization and makes it easier to use: You can query the same field that's, for example, in one file named `someMetadata` and in another `someMetaData` when using the sanitized key `somemetadata`. 
 
 In addition, the **bold field key is missing its formatting tokens**. Even though the `**` used to make it appear bold are part of the key name in the file, they are left out when indexing your note. The same goes for all other built-in formatting, like strike through or italic. This means formatted keys can only be queried without their formatting. This allows you to format the key in context of the note without worrying that you might create different keys for the same type of information. 
 

--- a/docs/docs/annotation/metadata-tasks.md
+++ b/docs/docs/annotation/metadata-tasks.md
@@ -62,7 +62,7 @@ As with pages, Dataview adds a number of implicit fields to each task or list it
 | `completed` |  Boolean  | Whether or not this *specific* task has been completed; this does not consider the completionnon-completion of any child tasks. A task is explicitly considered "completed" if it has been marked with an 'x'. If you use a custom status, i.e. `[-]`, `checked` will be true, whereas `completed` will be false. |
 | `fullyCompleted` |  Boolean  | Whether or not this task and **all** of its subtasks are completed. |
 | `text` |  Text  | The plain text of this task, including any metadata field annotations. |
-| `visual` | Text | The text of this task, which is rendered by Dataview. It can be modified to render arbitary text. |
+| `visual` | Text | The text of this task, which is rendered by Dataview. It can be modified to render arbitrary text. |
 | `line` |  Number  | The line of the file this task shows up on. |
 | `lineCount` |  Number  | The number of Markdown lines that this task takes up. |
 | `path` |  Text  | The full path of the file this task is in. Equals to `file.path` for [pages](./metadata-pages.md) |

--- a/docs/docs/annotation/types-of-metadata.md
+++ b/docs/docs/annotation/types-of-metadata.md
@@ -25,7 +25,7 @@ Most of the time you do not need to worry too much about the type of your fields
 
     | File (1) | date1 | date2 |
     | -------- | ----- | ----- |
-    | Untitled 2 | 3:15 PM - Februar 26, 2021 | 2021-04-17 18:00 |
+    | Untitled 2 | 3:15 PM - February 26, 2021 | 2021-04-17 18:00 |
 
     `date1` is recognized as a **Date** while `date2` is a normal **Text** to dataview, that's why `date1` is parsed differently for you. Find out more on [Dates below](#date). 
 
@@ -121,7 +121,7 @@ WHERE birthday.month = date(now).month
 gives you back all birthdays happening this month. Curious about `date(now)`? Read more about it under [literals](./../../reference/literals/#dates).
 
 !!! info "Displaying of date objects"
-    Dataview renders date objects in a human readable format, i.e. `3:15 PM - Februar 26, 2021`. You can adjust how this format looks like in Dataview's Setting under "General" with "Date Format" and "Date + Time Format". If you want to adjust the format in a specific query only, use the [dateformat function](../../reference/functions/#dateformatdatedatetime-string).
+    Dataview renders date objects in a human readable format, i.e. `3:15 PM - February 26, 2021`. You can adjust how this format looks like in Dataview's Setting under "General" with "Date Format" and "Date + Time Format". If you want to adjust the format in a specific query only, use the [dateformat function](../../reference/functions/#dateformatdatedatetime-string).
 
 ### Duration
 

--- a/docs/docs/api/data-array.md
+++ b/docs/docs/api/data-array.md
@@ -54,7 +54,7 @@ export interface DataArray<T> {
     /** Limit the total number of entries in the array to the given value. */
     limit(count: number): DataArray<T>;
     /**
-     * Take a slice of the array. If `start` is undefined, it is assumed to be 0; if `end` is undefined, it is assumbed
+     * Take a slice of the array. If `start` is undefined, it is assumed to be 0; if `end` is undefined, it is assumed
      * to be the end of the array.
      */
     slice(start?: number, end?: number): DataArray<T>;
@@ -109,7 +109,7 @@ export interface DataArray<T> {
     to(key: string): DataArray<any>;
     /**
      * Recursively expand the given key, flattening a tree structure based on the key into a flat array. Useful for handling
-     * heirarchical data like tasks with 'subtasks'.
+     * hierarchical data like tasks with 'subtasks'.
      */
     expand(key: string): DataArray<any>;
 

--- a/docs/docs/queries/query-types.md
+++ b/docs/docs/queries/query-types.md
@@ -215,7 +215,7 @@ TABLE
 !!! info "Disabling Result count"
     The first column always shows the result count. If you do not want to get it displayed, you can disable it in Dataview's settings ("Display result count", available since 0.5.52).
 
-Of course, a `TABLE` is made for specifying one to multiple additional informations:  
+Of course, a `TABLE` is made for specifying one to multiple additional information:  
 
 ~~~
 ```dataview
@@ -461,7 +461,7 @@ WHERE urgent
 
 ## CALENDAR
 
-The `CALENDAR` Query outputs a monthly based calendar where every result is depicted as a dot on it reffering date. The `CALENDAR` is the only Query Type that requires an additional information. This additional information needs to be a [date](../annotation/types-of-metadata.md#date) (or unset) on all queried pages. 
+The `CALENDAR` Query outputs a monthly based calendar where every result is depicted as a dot on it referring date. The `CALENDAR` is the only Query Type that requires an additional information. This additional information needs to be a [date](../annotation/types-of-metadata.md#date) (or unset) on all queried pages. 
 
 !!! summary "`CALENDAR` Query Type"
     The `CALENDAR` Query Types renders a calendar view where every result is represented by a dot on the given meta data field date.

--- a/docs/docs/queries/structure.md
+++ b/docs/docs/queries/structure.md
@@ -115,7 +115,7 @@ FROM (#assignment AND "30 School") OR ("30 School/32 Homeworks" AND outgoing([[S
 
 In addition to the Query Types and the **Data command** `FROM` that's explained above, you have several other **Data Commands** available that help you restrict, refine, sort or group your query results. 
 
-All data commands except the `FROM` command can be used **multiple times in any order** (as long as they come after the Query Type and `FROM`, if `FROM` is used at all). They'll be excuted in the order they are written.
+All data commands except the `FROM` command can be used **multiple times in any order** (as long as they come after the Query Type and `FROM`, if `FROM` is used at all). They'll be executed in the order they are written.
 
 Available are:
 

--- a/docs/docs/reference/expressions.md
+++ b/docs/docs/reference/expressions.md
@@ -134,7 +134,7 @@ WHERE status != "done"
     WHERE typeof(due) = "date" AND due <= date(today)
     ```
     ~~~
-    Most often, it is sufficient to check if the meta data is available via `WHERE due AND due <= date(today)`, but checking the type is the safer way to get forseeable results. 
+    Most often, it is sufficient to check if the meta data is available via `WHERE due AND due <= date(today)`, but checking the type is the safer way to get foreseeable results. 
 
 ### List/Object Indexing
 

--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -1,6 +1,6 @@
 # Functions
 
-Dataview functions provide more advanced ways to manipulate data. You can use functions **in [data commands](../queries/data-commands.md)** (except FROM) to filter or group or use them **as [additional informations](../queries/query-types.md)** like TABLE columns or extra output for LIST queries to see your data in a new light.
+Dataview functions provide more advanced ways to manipulate data. You can use functions **in [data commands](../queries/data-commands.md)** (except FROM) to filter or group or use them **as [additional information](../queries/query-types.md)** like TABLE columns or extra output for LIST queries to see your data in a new light.
 
 ## How functions work
 
@@ -59,7 +59,7 @@ Parses a date from the provided string, date, or link object, if possible, retur
 
 ```js
 date("2020-04-18") = <date object representing April 18th, 2020>
-date([[2021-04-16]]) = <date object for the given page, refering to file.day>
+date([[2021-04-16]]) = <date object for the given page, referring to file.day>
 ```
 
 ### `date(text, format)`

--- a/docs/docs/reference/literals.md
+++ b/docs/docs/reference/literals.md
@@ -46,7 +46,7 @@ Literal|Description
 `0`|The number zero
 `1337`|The positive number 1337
 `-200`| The negative number -200
-`"The quick brown fox jumps over the lazy dog"`| Text (sometimes reffered to as "string")
+`"The quick brown fox jumps over the lazy dog"`| Text (sometimes referred to as "string")
 `[[Science]]`|A link to the file named "Science"
 `[[]]`| A link to the current file
 `[1, 2, 3]`|A list of numbers 1, 2, and 3


### PR DESCRIPTION
Fixing some minor typos and spelling errors which should not affect functionality but improve the overall quality of documentation.