### PR TITLE
fix(ui): Check for changes before re-rendering JS blocks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -418,6 +418,19 @@ class GeneralSettingsTab extends PluginSettingTab {
                     })
             );
 
+        new Setting(this.containerEl)
+            .setName("Check Changes Before Re-Rendering")
+            .setDesc(
+                "If enabled, JS views will only re-render when the generated HTML is changed. This may fix flickering" +
+                    " issues, but also break complicated views with interactive elements."
+            )
+            .addToggle(toggle =>
+                toggle.setValue(this.plugin.settings.checkHTMLBeforeRerender).onChange(async value => {
+                    await this.plugin.updateSettings({ checkHTMLBeforeRerender: value });
+                    this.plugin.index.touch();
+                })
+            );
+
         let dformat = new Setting(this.containerEl)
             .setName("Date Format")
             .setDesc(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,8 @@ export interface QuerySettings {
     refreshEnabled: boolean;
     /** The interval that views are refreshed, by default. */
     refreshInterval: number;
+    /** Whether or not views should only re-render when underlying HTML is changed */
+    checkHTMLBeforeRerender: boolean;
     /** The default format that dates are rendered in (using luxon's moment-like formatting). */
     defaultDateFormat: string;
     /** The default format that date-times are rendered in (using luxons moment-like formatting). */
@@ -45,6 +47,7 @@ export const DEFAULT_QUERY_SETTINGS: QuerySettings = {
     warnOnEmptyResult: true,
     refreshEnabled: true,
     refreshInterval: 2500,
+    checkHTMLBeforeRerender: false,
     defaultDateFormat: "MMMM dd, yyyy",
     defaultDateTimeFormat: "h:mm a - MMMM dd, yyyy",
     maxRecursiveRenderDepth: 4,

--- a/src/ui/views/js-view.ts
+++ b/src/ui/views/js-view.ts
@@ -11,8 +11,8 @@ export class DataviewJSRenderer extends DataviewRefreshableRenderer {
     }
 
     async render() {
-        this.container.innerHTML = "";
         if (!this.settings.enableDataviewJs) {
+            this.container.innerHTML = "";
             this.containerEl.innerHTML = "";
             renderErrorPre(
                 this.container,
@@ -23,11 +23,19 @@ export class DataviewJSRenderer extends DataviewRefreshableRenderer {
 
         // Assume that the code is javascript, and try to eval it.
         try {
+            const dummyHTML = this.container.cloneNode() as HTMLElement;
             await asyncEvalInContext(
                 DataviewJSRenderer.PREAMBLE + this.script,
-                new DataviewInlineApi(this.api, this, this.container, this.origin)
+                new DataviewInlineApi(this.api, this, dummyHTML, this.origin)
             );
+            if (dummyHTML.innerHTML != this.container.innerHTML) {
+                this.container.innerHTML = "";
+                while (dummyHTML.firstChild) {
+                    this.container.appendChild(dummyHTML.firstChild);
+                }
+            }
         } catch (e) {
+            this.container.innerHTML = "";
             this.containerEl.innerHTML = "";
             renderErrorPre(this.container, "Evaluation Error: " + e.stack);
         }

--- a/src/ui/views/js-view.ts
+++ b/src/ui/views/js-view.ts
@@ -28,7 +28,7 @@ export class DataviewJSRenderer extends DataviewRefreshableRenderer {
                 DataviewJSRenderer.PREAMBLE + this.script,
                 new DataviewInlineApi(this.api, this, dummyHTML, this.origin)
             );
-            if (dummyHTML.innerHTML != this.container.innerHTML) {
+            if (!this.settings.checkHTMLBeforeRerender || dummyHTML.innerHTML != this.container.innerHTML) {
                 this.container.innerHTML = "";
                 while (dummyHTML.firstChild) {
                     this.container.appendChild(dummyHTML.firstChild);


### PR DESCRIPTION
Issue: #1075 

Hi, I saw this was an issue both personally, but also documented. This is a quick (and dirty) solution which renders the JS to a separate element, then moves the nodes over to the main container only if the HTML changed. This fixes the constant re-render issue, as it can only re-render if a dependency of the element changed (also input inside the element, through an input field for example, can cause a re-render but this is much harder to detect).