### PR TITLE
Update ttypescript to 1.5.15 to fix a compile failure when using node >=16.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-dataview",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-dataview",
-      "version": "0.5.55",
+      "version": "0.5.56",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "https://github.com/lishid/cm-language",
@@ -41,7 +41,7 @@
         "rollup-plugin-web-worker-loader": "^1.6.1",
         "ts-jest": "^27.0.5",
         "tslib": "^2.3.1",
-        "ttypescript": "^1.5.12",
+        "ttypescript": "^1.5.15",
         "typescript": "^4.4.2"
       }
     },
@@ -6644,9 +6644,9 @@
       "dev": true
     },
     "node_modules/ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "dependencies": {
         "resolve": ">=1.9.0"
@@ -12149,9 +12149,9 @@
       "dev": true
     },
     "ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "requires": {
         "resolve": ">=1.9.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rollup-plugin-web-worker-loader": "^1.6.1",
     "ts-jest": "^27.0.5",
     "tslib": "^2.3.1",
-    "ttypescript": "^1.5.12",
+    "ttypescript": "^1.5.15",
     "typescript": "^4.4.2"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, cloning this repo, running `npm install` or even `npm ci` installs ttypescript 1.5.13.  Using this version of ttypescript causes the `npm run dev` command to fail with the following error:

```bash
npm run dev

> obsidian-dataview@0.5.56 dev
> npx rollup --config rollup.config.js -w

[!] TypeError: Cannot set property constructor of [object Object] which has only a getter
TypeError: Cannot set property constructor of [object Object] which has only a getter
    at new __ (/Users/johnalb/src/personal/obsidian_dev/obsidian-dataview/node_modules/ttypescript/lib/loadTypescript.js:13:42)
    at __extends (/Users/johnalb/src/personal/obsidian_dev/obsidian-dataview/node_modules/ttypescript/lib/loadTypescript.js:14:84)
    at /Users/johnalb/src/personal/obsidian_dev/obsidian-dataview/node_modules/ttypescript/lib/loadTypescript.js:65:5
    at Object.<anonymous> (/Users/johnalb/src/personal/obsidian_dev/obsidian-dataview/node_modules/ttypescript/lib/loadTypescript.js:100:2)
    at Module._compile (node:internal/modules/cjs/loader:1233:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1287:10)
    at Object.require.extensions.<computed> [as .js] (/Users/johnalb/src/personal/obsidian_dev/obsidian-dataview/node_modules/rollup/dist/shared/loadConfigFile.js:617:17)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Function.Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
```

Updating to ttypescript 1.5.15 fixes [this bug][1].

[1]: https://github.com/cevek/ttypescript/issues/139

