### PR TITLE
Fix typo

### DIFF
--- a/docs/docs/api/code-reference.md
+++ b/docs/docs/api/code-reference.md
@@ -408,7 +408,7 @@ Equivalent to `dv.query()`, but returns rendered Markdown.
 
 ```js
 await dv.queryMarkdown("LIST FROM #tag") =>
-    { successfult: true, value: { "- [[Page 1]]\n- [[Page 2]]" } }
+    { successful: true, value: { "- [[Page 1]]\n- [[Page 2]]" } }
 ```
 
 ### ⌛ `dv.tryQueryMarkdown(source, [file], [settings])`


### PR DESCRIPTION
This PR fixes a typo in the `queryMarkdown` documentation: The return status is `successful`, not `successfult`.