### PR TITLE
Add support for frontmatter links. Requires obsidian v1.4.0+.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+      - run: npm install
       - run: npm run check-format
   build:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "rollup-plugin-web-worker-loader": "^1.6.1",
         "ts-jest": "^27.0.5",
         "tslib": "^2.3.1",
-        "ttypescript": "^1.5.12",
+        "ttypescript": "^1.5.15",
         "typescript": "^4.4.2"
       }
     },
@@ -6658,9 +6658,9 @@
       "dev": true
     },
     "node_modules/ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "dependencies": {
         "resolve": ">=1.9.0"
@@ -12173,9 +12173,9 @@
       "dev": true
     },
     "ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "requires": {
         "resolve": ">=1.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-dataview",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-dataview",
-      "version": "0.5.55",
+      "version": "0.5.56",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "https://github.com/lishid/cm-language",
@@ -32,7 +32,7 @@
         "@zerollup/ts-transform-paths": "^1.7.18",
         "compare-versions": "^4.1.1",
         "jest": "^27.1.0",
-        "obsidian": "^1.2.8",
+        "obsidian": "^1.4.0",
         "prettier": "2.3.2",
         "rollup": "^2.67.2",
         "rollup-jest": "^1.1.3",
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/@types/codemirror": {
-      "version": "0.0.108",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
-      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
       "dependencies": {
         "@types/tern": "*"
       }
@@ -5568,11 +5568,12 @@
       "dev": true
     },
     "node_modules/obsidian": {
-      "version": "1.2.8",
-      "resolved": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#583ba39e3f6c0546de5e5e8742256a60e2d78ebc",
-      "license": "MIT",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.0.tgz",
+      "integrity": "sha512-fsZMPlxgflGSBSP6P4BjQi5+0MqZl3h6FEDEZ3CNnweNdDw0doyqN3FMO/PGWfuxPT77WicVwUxekuI3e6eCGg==",
+      "dev": true,
       "dependencies": {
-        "@types/codemirror": "0.0.108",
+        "@types/codemirror": "5.60.8",
         "moment": "2.29.4"
       },
       "peerDependencies": {
@@ -5605,6 +5606,19 @@
       },
       "bin": {
         "obsidian-daily-notes-interface": "dist/main.js"
+      }
+    },
+    "node_modules/obsidian-daily-notes-interface/node_modules/obsidian": {
+      "version": "1.4.4",
+      "resolved": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#5178e27f0eb12741c79914f52146de8ff827e390",
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/obsidian-daily-notes-interface/node_modules/tslib": {
@@ -8091,9 +8105,9 @@
       }
     },
     "@types/codemirror": {
-      "version": "0.0.108",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
-      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
       "requires": {
         "@types/tern": "*"
       }
@@ -11373,10 +11387,12 @@
       "dev": true
     },
     "obsidian": {
-      "version": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#583ba39e3f6c0546de5e5e8742256a60e2d78ebc",
-      "from": "obsidian@^1.2.8",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.0.tgz",
+      "integrity": "sha512-fsZMPlxgflGSBSP6P4BjQi5+0MqZl3h6FEDEZ3CNnweNdDw0doyqN3FMO/PGWfuxPT77WicVwUxekuI3e6eCGg==",
+      "dev": true,
       "requires": {
-        "@types/codemirror": "0.0.108",
+        "@types/codemirror": "5.60.8",
         "moment": "2.29.4"
       }
     },
@@ -11406,6 +11422,14 @@
         "tslib": "2.1.0"
       },
       "dependencies": {
+        "obsidian": {
+          "version": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#5178e27f0eb12741c79914f52146de8ff827e390",
+          "from": "obsidian@github:obsidianmd/obsidian-api#master",
+          "requires": {
+            "@types/codemirror": "5.60.8",
+            "moment": "2.29.4"
+          }
+        },
         "tslib": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rollup-plugin-web-worker-loader": "^1.6.1",
     "ts-jest": "^27.0.5",
     "tslib": "^2.3.1",
-    "ttypescript": "^1.5.12",
+    "ttypescript": "^1.5.15",
     "typescript": "^4.4.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@zerollup/ts-transform-paths": "^1.7.18",
     "compare-versions": "^4.1.1",
     "jest": "^27.1.0",
-    "obsidian": "^1.2.8",
+    "obsidian": "^1.4.0",
     "prettier": "2.3.2",
     "rollup": "^2.67.2",
     "rollup-jest": "^1.1.3",

--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -358,25 +358,19 @@ export class DataviewApi {
      * execution via `result.successful` and obtain `result.value` or `result.error` resultingly. If
      * you'd rather this method throw on an error, use `dv.tryEvaluate`.
      */
-    public evaluate(
-        expression: string,
-        context?: DataObject,
-        originFile?: string): Result<Literal, string> {
+    public evaluate(expression: string, context?: DataObject, originFile?: string): Result<Literal, string> {
         let field = EXPRESSION.field.parse(expression);
         if (!field.status) return Result.failure(`Failed to parse expression "${expression}"`);
 
         let evaluationContext = originFile
             ? new Context(defaultLinkHandler(this.index, originFile), this.settings)
-            : this.evaluationContext
+            : this.evaluationContext;
 
         return evaluationContext.evaluate(field.value, context);
     }
 
     /** Error-throwing version of `dv.evaluate`. */
-    public tryEvaluate(
-        expression: string,
-        context?: DataObject,
-        originFile?: string): Literal {
+    public tryEvaluate(expression: string, context?: DataObject, originFile?: string): Literal {
         return this.evaluate(expression, context, originFile).orElseThrow();
     }
 

--- a/src/data-import/markdown-file.ts
+++ b/src/data-import/markdown-file.ts
@@ -43,7 +43,7 @@ export function parsePage(path: string, contents: string, stat: FileStats, metad
         }
     }
 
-  // Links in metadata.
+    // Links in metadata.
     const linksByLine: Record<number, Link[]> = {};
     for (let rawLink of metadata.links || []) {
         const link = Link.infer(rawLink.link, false, rawLink.displayText);

--- a/src/data-import/markdown-file.ts
+++ b/src/data-import/markdown-file.ts
@@ -35,7 +35,15 @@ export function parsePage(path: string, contents: string, stat: FileStats, metad
         }
     }
 
-    // Links in metadata.
+    // Add frontmatter links to links.
+    if (metadata.frontmatterLinks) {
+        for (let rawLink of metadata.frontmatterLinks || []) {
+            const link = Link.infer(rawLink.link, false, rawLink.displayText);
+            links.push(link);
+        }
+    }
+
+  // Links in metadata.
     const linksByLine: Record<number, Link[]> = {};
     for (let rawLink of metadata.links || []) {
         const link = Link.infer(rawLink.link, false, rawLink.displayText);


### PR DESCRIPTION
## Issues

- Fixes #2029 
- Fixes #2019

## Changes

- Adds frontmatter links to `file.outlinks` and `file.inlinks`
- Sets the minimum obsidian dependency version at least v.1.4.0

## Context

The new [Obsidian 1.4.5](https://obsidian.md/changelog/2023-08-31-desktop-v1.4.5/) release added a new feature called Properties. One of the things it does is add support wiki-style links (e.g. `[[]]`) in the yaml frontmatter (if propertly quoted). These links are not added to the `.links` property in `CachedMetadata`. Instead they are added as a new and separate property called `.frontmatterLinks`.

I believe that my change of adding the `CachedMetadata.frontmatterLinks` to `PageMetadata.links` resolves the issues described in #2019 and #2029 where `file.outlinks` and `file.inlinks` do not include links added to notes in yaml frontmatter using the new Properties functionality.

### Note about the API

The [web API docs](https://docs.obsidian.md/Reference/TypeScript+API/CachedMetadata/CachedMetadata) are out of date. You can see the update to the `CachedMetadata` class in the [latest API source code](https://github.com/obsidianmd/obsidian-api/blob/5178e27f0eb12741c79914f52146de8ff827e390/obsidian.d.ts#L511) was added in [v1.4.0](https://github.com/obsidianmd/obsidian-api/commit/90517f4fa762838008a638069d8e151f071a8ef7) and is documented in the [changelog](https://github.com/obsidianmd/obsidian-api/blob/master/CHANGELOG.md).

### Other impacts

I ran `npm run test` and all the tests pass, but I'm not sure if there are other concerns with either of these changes (i.e. updating the minimum dependency version and adding frontmatter links to `file.outlinks` and `file.inlinks`. I could definitely use some advice from the maintainers and/or core contributors on this.

## Testing

You can test this out by doing the following.

Verify that frontmatter links **are not** included in `file.inlinks` and `file.outlinks` without this patch:

1. Update to Obsidian 1.4.5
2. Create a new note and add a frontmatter link using the new Properties interface to an existing note (or you can also just do something like `myprop: "[[existing note]]"` in source code mode if you don't want to use the Properties interface)
3. Create a dataview that looks something like this and verify that the outcome is that no outlinks are displayed:

```
LIST file.outlinks
WHERE file.name = "<new note name>"
```
4. Create a dataview that looks something like this and verify that the outcome is that no inlinks are displayed:

```
LIST file.inlinks
WHERE file.name = "<the note you linked to>"
```

Verify that frontmatter links **are** included in `file.inlinks` and `file.outlinks` with this patch:

1. Update to Obsidian 1.4.5
2. Update the Dataview plugin to use this branch. Make sure to run `npm install` to update the dependencies
3. The above dataviews should now render links
