### PR TITLE
Update code formatting CI job to fix failures and run prettier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+      - run: npm install
       - run: npm run check-format
   build:
     runs-on: ubuntu-latest

--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -358,25 +358,19 @@ export class DataviewApi {
      * execution via `result.successful` and obtain `result.value` or `result.error` resultingly. If
      * you'd rather this method throw on an error, use `dv.tryEvaluate`.
      */
-    public evaluate(
-        expression: string,
-        context?: DataObject,
-        originFile?: string): Result<Literal, string> {
+    public evaluate(expression: string, context?: DataObject, originFile?: string): Result<Literal, string> {
         let field = EXPRESSION.field.parse(expression);
         if (!field.status) return Result.failure(`Failed to parse expression "${expression}"`);
 
         let evaluationContext = originFile
             ? new Context(defaultLinkHandler(this.index, originFile), this.settings)
-            : this.evaluationContext
+            : this.evaluationContext;
 
         return evaluationContext.evaluate(field.value, context);
     }
 
     /** Error-throwing version of `dv.evaluate`. */
-    public tryEvaluate(
-        expression: string,
-        context?: DataObject,
-        originFile?: string): Literal {
+    public tryEvaluate(expression: string, context?: DataObject, originFile?: string): Literal {
         return this.evaluate(expression, context, originFile).orElseThrow();
     }
 


### PR DESCRIPTION
Similar to #2021, currently, the CI "Check code formatting" job is failing on `master`:

```
> obsidian-dataview@0.5.56 check-format
> npx prettier --check src

npm WARN exec The following package was not found and will be installed: prettier@3.0.3
Checking formatting...
[warn] src/api/data-array.ts
[warn] src/api/inline-api.ts
[warn] src/api/plugin-api.ts
[warn] src/api/result.ts
[warn] src/data-import/inline-field.ts
[warn] src/data-import/markdown-file.ts
[warn] src/data-import/persister.ts
[warn] src/data-import/web-worker/import-impl.ts
[warn] src/data-import/web-worker/import-manager.ts
[warn] src/data-index/index.ts
[warn] src/data-index/resolver.ts
[warn] src/data-model/markdown.ts
[warn] src/data-model/value.ts
[warn] src/expression/binaryop.ts
[warn] src/expression/context.ts
[warn] src/expression/functions.ts
[warn] src/expression/parse.ts
[warn] src/main.ts
[warn] src/query/engine.ts
[warn] src/query/parse.ts
[warn] src/test/api/data-array.test.ts
[warn] src/test/function/eval.test.ts
[warn] src/test/function/functions.test.ts
[warn] src/test/function/string.test.ts
[warn] src/test/markdown/parse.file.test.ts
[warn] src/test/parse/parse.expression.test.ts
[warn] src/test/parse/parse.query.test.ts
[warn] src/ui/export/markdown.ts
[warn] src/ui/lp-render.ts
[warn] src/ui/markdown.tsx
[warn] src/ui/refreshable-view.ts
[warn] src/ui/render.ts
[warn] src/ui/views/calendar-view.ts
[warn] src/ui/views/inline-field.tsx
[warn] src/ui/views/inline-view.ts
[warn] src/ui/views/js-view.ts
[warn] src/ui/views/list-view.tsx
[warn] src/ui/views/table-view.tsx
[warn] src/ui/views/task-view.tsx
[warn] src/util/media.ts
[warn] src/util/normalize.ts
[warn] Code style issues found in 41 files. Run Prettier to fix.
Error: Process completed with exit code 1.
```

This is not happening locally and is resolved by this PR, which:
1. Changes the format-check CI job to run `npm run install` before running prettier check
2. Runs prettier on `master` to format existing code.

Note that the build step in the CI job will fail due to the issue identified in #2021. I have not pulled in that change to keep this PR targeted and narrow, but that's easy to do, if requested.