### PR TITLE
fix: readd correct rollup typescript config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -65,7 +65,7 @@ const LIBRARY_CONFIG = {
         name: "Dataview (Library)",
     },
     plugins: getRollupPlugins(
-        "tsconfig-lib.json",
+        { tsconfig: "tsconfig-lib.json" },
         copy({ targets: [{ src: "src/typings/*.d.ts", dest: "lib/typings" }] })
     ),
 };


### PR DESCRIPTION
Looks like this was dropped accidentally when removing reliance on ttypescript. Fixes #2073