### PR TITLE
Fix editor extension settings not properly reflected

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -99,11 +99,10 @@ export default class DataviewPlugin extends Plugin {
             }
         });
 
-        // editor extension for inline queries
-        if (this.settings.enableInlineDataview || this.settings.enableInlineDataviewJs) {
-            this.cmExtension = [inlinePlugin(this.app, this.index, this.settings, this.api)];
-            this.registerEditorExtension(this.cmExtension);
-        }
+        // editor extensions
+        this.cmExtension = [];
+        this.registerEditorExtension(this.cmExtension);
+        this.updateEditorExtensions();
 
         // Dataview "force refresh" operation.
         this.addCommand({
@@ -146,8 +145,6 @@ export default class DataviewPlugin extends Plugin {
                 });
             })
         );
-        this.registerEditorExtension(inlineFieldsField);
-        this.registerEditorExtension(replaceInlineFieldsInLivePreview(this.app, this.settings));
     }
 
     private debouncedRefresh: () => void = () => null;
@@ -181,6 +178,21 @@ export default class DataviewPlugin extends Plugin {
     ) {
         let registered = this.registerMarkdownCodeBlockProcessor(language, processor);
         registered.sortOrder = priority;
+    }
+
+    public updateEditorExtensions() {
+        // Don't create a new array, keep the same reference
+        this.cmExtension.length = 0;
+        // editor extension for inline queries: enabled regardless of settings (enableInlineDataview/enableInlineDataviewJS)
+        this.cmExtension.push(inlinePlugin(this.app, this.index, this.settings, this.api));
+        // editor extension for rendering inline fields in live preview
+        if (this.settings.prettyRenderInlineFields) {
+            this.cmExtension.push(
+                inlineFieldsField,
+                replaceInlineFieldsInLivePreview(this.app, this.settings),
+            )
+        }
+        this.app.workspace.updateOptions();
     }
 
     /**
@@ -326,7 +338,10 @@ class GeneralSettingsTab extends PluginSettingTab {
             .addToggle(toggle =>
                 toggle
                     .setValue(this.plugin.settings.prettyRenderInlineFields)
-                    .onChange(async value => await this.plugin.updateSettings({ prettyRenderInlineFields: value }))
+                    .onChange(async value => {
+                        await this.plugin.updateSettings({ prettyRenderInlineFields: value });
+                        this.plugin.updateEditorExtensions();
+                    })
             );
 
         this.containerEl.createEl("h2", { text: "Codeblock Settings" });

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -12,16 +12,15 @@ export async function renderCompactMarkdown(
     sourcePath: string,
     component: Component
 ) {
-    let subcontainer = container.createSpan();
-    await MarkdownRenderer.renderMarkdown(markdown, subcontainer, sourcePath, component);
+    const tmpContainer = createSpan();
+    await MarkdownRenderer.renderMarkdown(markdown, tmpContainer, sourcePath, component);
 
-    let paragraph = subcontainer.querySelector(":scope > p");
-    if (subcontainer.children.length == 1 && paragraph) {
-        while (paragraph.firstChild) {
-            subcontainer.appendChild(paragraph.firstChild);
-        }
-        subcontainer.removeChild(paragraph);
+    let paragraph = tmpContainer.querySelector(":scope > p");
+    if (tmpContainer.childNodes.length == 1 && paragraph) {
+        container.replaceChildren(...paragraph.childNodes);
     }
+
+    tmpContainer.remove();
 }
 
 /** Render a pre block with an error in it; returns the element to allow for dynamic updating. */

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -168,12 +168,7 @@ class InlineFieldWidget extends WidgetType {
                 },
             });
 
-            renderCompactMarkdown(
-                this.field.key,
-                key,
-                this.sourcePath,
-                this.parentComponent
-            );
+            renderCompactMarkdown(this.field.key, key, this.sourcePath, this.parentComponent);
 
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-value"],

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -1,4 +1,4 @@
-import { App, Component, MarkdownRenderer, editorInfoField, editorLivePreviewField } from "obsidian";
+import { App, Component, editorInfoField, editorLivePreviewField } from "obsidian";
 import { EditorState, RangeSet, RangeSetBuilder, RangeValue, StateEffect, StateField } from "@codemirror/state";
 import {
     Decoration,
@@ -11,7 +11,7 @@ import {
 } from "@codemirror/view";
 import { InlineField, extractInlineFields, parseInlineValue } from "data-import/inline-field";
 import { canonicalizeVarName } from "util/normalize";
-import { renderValue } from "ui/render";
+import { renderCompactMarkdown, renderValue } from "ui/render";
 import { DataviewSettings } from "settings";
 
 class InlineFieldValue extends RangeValue {
@@ -168,8 +168,12 @@ class InlineFieldWidget extends WidgetType {
                 },
             });
 
-            // Explicitly set the inner HTML to respect any key formatting that we should carry over.
-            this.renderMarkdown(key, this.field.key);
+            renderCompactMarkdown(
+                this.field.key,
+                key,
+                this.sourcePath,
+                this.parentComponent
+            );
 
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-value"],
@@ -200,28 +204,6 @@ class InlineFieldWidget extends WidgetType {
 
         return renderContainer;
     }
-
-    async renderMarkdown(el: HTMLElement, source: string) {
-        const children = await renderMarkdown(this.app, source, this.sourcePath, this.parentComponent);
-        if (children) el.replaceChildren(...children);
-    }
-}
-
-/** Easy-to-use version of MarkdownRenderer.render. Returns only the child nodes intead of a container block. */
-export async function renderMarkdown(
-    app: App,
-    markdown: string,
-    sourcePath: string,
-    component: Component
-): Promise<NodeList | null> {
-    const el = createSpan();
-    await MarkdownRenderer.render(app, markdown, el, sourcePath, component);
-    for (const child of el.children) {
-        if (child.tagName == "P") {
-            return child.childNodes;
-        }
-    }
-    return null;
 }
 
 /**


### PR DESCRIPTION
## Bug description

1. If neither "Enable Inline Queries" (`settings.enableInlineDataview`) nor "Enable Inline JavaScript Queries" (`settings.enableInlineDataviewJS`) is turned off when the plugin's loading, any inline queries are not enabled even if these settings are turned on later on.
2. Inline fields are rendered regardless of the setting "Enable Inline Fields Highlighting" (`settings.prettyRenderInlineFields`).

1 is caused by how `cmExtension` is treated in the plugin's `onload` method: 
https://github.com/blacksmithgu/obsidian-dataview/blob/52fcd0b13eff80bab9769716baae6a77ff57aa78/src/main.ts#L102-L106

Here, the comment mentions dynamic updates, but in fact, the editor extensions are not dynamically updated at all.

https://github.com/blacksmithgu/obsidian-dataview/blob/52fcd0b13eff80bab9769716baae6a77ff57aa78/src/main.ts#L41-L42

So, I updated `main.ts` so that the editor extensions are dynamically updated according to the settings.

https://github.com/RyotaUshio/obsidian-dataview/blob/892d343ea9b9845221e2c7ee604ad46bc4d73f0e/src/main.ts#L183-L196

https://github.com/RyotaUshio/obsidian-dataview/blob/892d343ea9b9845221e2c7ee604ad46bc4d73f0e/src/main.ts#L343

Thank you!