### PR TITLE
Fix editor extension settings not properly reflected

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -99,11 +99,10 @@ export default class DataviewPlugin extends Plugin {
             }
         });
 
-        // editor extension for inline queries
-        if (this.settings.enableInlineDataview || this.settings.enableInlineDataviewJs) {
-            this.cmExtension = [inlinePlugin(this.app, this.index, this.settings, this.api)];
-            this.registerEditorExtension(this.cmExtension);
-        }
+        // editor extensions
+        this.cmExtension = [];
+        this.registerEditorExtension(this.cmExtension);
+        this.updateEditorExtensions();
 
         // Dataview "force refresh" operation.
         this.addCommand({
@@ -146,8 +145,6 @@ export default class DataviewPlugin extends Plugin {
                 });
             })
         );
-        this.registerEditorExtension(inlineFieldsField);
-        this.registerEditorExtension(replaceInlineFieldsInLivePreview(this.app, this.settings));
     }
 
     private debouncedRefresh: () => void = () => null;
@@ -181,6 +178,21 @@ export default class DataviewPlugin extends Plugin {
     ) {
         let registered = this.registerMarkdownCodeBlockProcessor(language, processor);
         registered.sortOrder = priority;
+    }
+
+    public updateEditorExtensions() {
+        // Don't create a new array, keep the same reference
+        this.cmExtension.length = 0;
+        // editor extension for inline queries: enabled regardless of settings (enableInlineDataview/enableInlineDataviewJS)
+        this.cmExtension.push(inlinePlugin(this.app, this.index, this.settings, this.api));
+        // editor extension for rendering inline fields in live preview
+        if (this.settings.prettyRenderInlineFields) {
+            this.cmExtension.push(
+                inlineFieldsField,
+                replaceInlineFieldsInLivePreview(this.app, this.settings),
+            )
+        }
+        this.app.workspace.updateOptions();
     }
 
     /**
@@ -326,7 +338,10 @@ class GeneralSettingsTab extends PluginSettingTab {
             .addToggle(toggle =>
                 toggle
                     .setValue(this.plugin.settings.prettyRenderInlineFields)
-                    .onChange(async value => await this.plugin.updateSettings({ prettyRenderInlineFields: value }))
+                    .onChange(async value => {
+                        await this.plugin.updateSettings({ prettyRenderInlineFields: value });
+                        this.plugin.updateEditorExtensions();
+                    })
             );
 
         this.containerEl.createEl("h2", { text: "Codeblock Settings" });

--- a/src/main.ts
+++ b/src/main.ts
@@ -187,10 +187,7 @@ export default class DataviewPlugin extends Plugin {
         this.cmExtension.push(inlinePlugin(this.app, this.index, this.settings, this.api));
         // editor extension for rendering inline fields in live preview
         if (this.settings.prettyRenderInlineFields) {
-            this.cmExtension.push(
-                inlineFieldsField,
-                replaceInlineFieldsInLivePreview(this.app, this.settings),
-            )
+            this.cmExtension.push(inlineFieldsField, replaceInlineFieldsInLivePreview(this.app, this.settings));
         }
         this.app.workspace.updateOptions();
     }
@@ -336,12 +333,10 @@ class GeneralSettingsTab extends PluginSettingTab {
             .setName("Enable Inline Field Highlighting")
             .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields.")
             .addToggle(toggle =>
-                toggle
-                    .setValue(this.plugin.settings.prettyRenderInlineFields)
-                    .onChange(async value => {
-                        await this.plugin.updateSettings({ prettyRenderInlineFields: value });
-                        this.plugin.updateEditorExtensions();
-                    })
+                toggle.setValue(this.plugin.settings.prettyRenderInlineFields).onChange(async value => {
+                    await this.plugin.updateSettings({ prettyRenderInlineFields: value });
+                    this.plugin.updateEditorExtensions();
+                })
             );
 
         this.containerEl.createEl("h2", { text: "Codeblock Settings" });


### PR DESCRIPTION
## Bug description

1. If both "Enable Inline Queries" (`settings.enableInlineDataview`) and "Enable Inline JavaScript Queries" (`settings.enableInlineDataviewJS`) are turned off when the plugin's loading, any inline queries are not enabled even if these settings are turned on later on.
2. Inline fields are rendered regardless of the setting "Enable Inline Fields Highlighting" (`settings.prettyRenderInlineFields`).

## Steps to reproduce bug 1

1. Turn off "Enable Inline Queries" and "Enable Inline JavaScript Queries".
2. Disable Dataview
3. Enable Dataview
4. Turn on "Enable Inline Queries" and "Enable Inline JavaScript Queries". Now, inline queries should be rendered in live preview, but they are not.


## Solution

1 is caused by how `cmExtension` is treated in the plugin's `onload` method: 
https://github.com/blacksmithgu/obsidian-dataview/blob/52fcd0b13eff80bab9769716baae6a77ff57aa78/src/main.ts#L102-L106

Here, the comment mentions dynamic updates, but in fact, the editor extensions are not updated at all after the initial loading.

https://github.com/blacksmithgu/obsidian-dataview/blob/52fcd0b13eff80bab9769716baae6a77ff57aa78/src/main.ts#L41-L42

So, I updated `main.ts` so that the editor extensions are dynamically updated according to the settings. This also resolves 2.

https://github.com/RyotaUshio/obsidian-dataview/blob/83524a47f30508cde5be99b74a6dd987c58e3e56/src/main.ts#L183-L196

https://github.com/RyotaUshio/obsidian-dataview/blob/83524a47f30508cde5be99b74a6dd987c58e3e56/src/main.ts#L343

Thank you!