### PR TITLE
Fix inline queries inside a Canvas note card are not given the current file info correctly in live preview

### DIFF
--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -196,10 +196,10 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                     exists = true;
                 });
                 if (!exists) {
-                    /** 
+                    /**
                      * In a note embedded in a Canvas, app.workspace.getActiveFile() returns
-                     * the canvas file, not the note file. On the other hand, 
-                     * view.state.field(editorInfoField).file returns the note file itself, 
+                     * the canvas file, not the note file. On the other hand,
+                     * view.state.field(editorInfoField).file returns the note file itself,
                      * which is more suitable here.
                      */
                     const currentFile = view.state.field(editorInfoField).file;

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -196,7 +196,13 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                     exists = true;
                 });
                 if (!exists) {
-                    const currentFile = app.workspace.getActiveFile();
+                    /** 
+                     * In a note embedded in a Canvas, app.workspace.getActiveFile() returns
+                     * the canvas file, not the note file. On the other hand, 
+                     * view.state.field(editorInfoField).file returns the note file itself, 
+                     * which is more suitable here.
+                     */
+                    const currentFile = view.state.field(editorInfoField).file;
                     if (!currentFile) return;
                     const newDeco = this.renderWidget(node, view, currentFile)?.value;
                     if (newDeco) {

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -249,7 +249,7 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
             inlineRender(view: EditorView) {
                 // still doesn't work as expected for tables and callouts
                 if (!index.initialized) return;
-                const currentFile = app.workspace.getActiveFile();
+                const currentFile = view.state.field(editorInfoField).file;
                 if (!currentFile) return;
 
                 const widgets: Range<Decoration>[] = [];


### PR DESCRIPTION
This PR fixes the bug where inline queries inside a Canvas note card are not given the current file info correctly in editing mode, and as a result, a query like `=this.file.name` is not correctly processed.

## Steps to reproduce

1. Create a note titled `Test note.md` with the following content:
```
`=this.file.name`
`$=dv.current().file.name`
```

2. Create a new Canvas, and add `Test note.md` to it as a card ("Drag to add note from vault")

3. Double-click the card to enter live preview mode

4. You will see inline queries are not correctly processed:

![image](https://github.com/blacksmithgu/obsidian-dataview/assets/72342591/39aa0bb0-6a19-4bc5-bd0b-f660ebad6202)

## Solution 

I identified the root cause as these lines in `lp-render.ts`:

https://github.com/blacksmithgu/obsidian-dataview/blob/52fcd0b13eff80bab9769716baae6a77ff57aa78/src/ui/lp-render.ts#L199

https://github.com/blacksmithgu/obsidian-dataview/blob/52fcd0b13eff80bab9769716baae6a77ff57aa78/src/ui/lp-render.ts#L246

It uses `Workspace.getActiveFile()` to get the current file, but it returns the canvas file when editing `Test node.md` through a canvas.
We have to use the `editorInfoField` state field instead to get the file that is actually edited.

## Result

Now, these inline queries are correctly processed. 

<img alt="image" src="https://github.com/blacksmithgu/obsidian-dataview/assets/72342591/b5fa972b-3f5d-4b23-8053-a7d4343186cd">


