### PR TITLE
Revert the change for `renderCompactMarkdown` to fix `dv.paragraph()` with lists

### DIFF
--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -12,15 +12,16 @@ export async function renderCompactMarkdown(
     sourcePath: string,
     component: Component
 ) {
-    const tmpContainer = createSpan();
-    await MarkdownRenderer.renderMarkdown(markdown, tmpContainer, sourcePath, component);
+    let subcontainer = container.createSpan();
+    await MarkdownRenderer.renderMarkdown(markdown, subcontainer, sourcePath, component);
 
-    let paragraph = tmpContainer.querySelector(":scope > p");
-    if (tmpContainer.childNodes.length == 1 && paragraph) {
-        container.replaceChildren(...paragraph.childNodes);
+    let paragraph = subcontainer.querySelector(":scope > p");
+    if (subcontainer.children.length == 1 && paragraph) {
+        while (paragraph.firstChild) {
+            subcontainer.appendChild(paragraph.firstChild);
+        }
+        subcontainer.removeChild(paragraph);
     }
-
-    tmpContainer.remove();
 }
 
 /** Render a pre block with an error in it; returns the element to allow for dynamic updating. */

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -77,7 +77,7 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                 for (const { from, to } of view.visibleRanges) {
                     info.between(from, to, (start, end, { field }) => {
                         // If the inline field is not overlapping with the cursor, we replace it with a widget.
-                        if (selectionAndRangeOverlap(selection, start, end)) {
+                        if (!selectionAndRangeOverlap(selection, start, end)) {
                             builder.add(
                                 start,
                                 end,


### PR DESCRIPTION
I noticed the current latest version (fdc0709) has a crucial bug where `dv.paragraph(source)` doesn't render anything when `source` contains a list. For example,  

````md
```dataviewjs
dv.paragraph(`
- list item 1
- list item 2
`)
```
````

this should render the following list, but nothing is rendered.

<img width="560" alt="image" src="https://github.com/blacksmithgu/obsidian-dataview/assets/72342591/fff6cb9d-25ea-4acc-9898-8b1a6c772420">

I've identified the cause as the change I made to `renderCompactMarkdown()` in `src/ui/render.ts` in PR #2089 to alleviate the MathJax flickering issue in the live preview. 
(I'm not sure why it caused the problem, but after reverting the list above was rendered correctly.)
Now that the flickering has been entirely eliminated by rewriting the updating process of CM decorations, the change in `renderCompactMarkdown()` can be reverted without the recurrence of flickering issue.

My apologies for bringing in this bug.

 