### PR TITLE
Reduce height error-box

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -115,7 +115,7 @@
 
 div.dataview-error-box {
     width: 100%;
-    min-height: 150px;
+    min-height: 50px;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
It just reduces the height of the error-box following #1968 

![Screenshot from 2023-10-11 12-24-14](https://github.com/blacksmithgu/obsidian-dataview/assets/92447129/1a488cd6-0c21-4d35-aa18-f2a7efcd79de)

![Screenshot from 2023-10-11 12-23-13](https://github.com/blacksmithgu/obsidian-dataview/assets/92447129/4b86ebc6-08ab-4919-ab8e-97f3345ac426)