### PR TITLE
Resolve #2101: add a click event handler to inline field widgets in live preview

### DIFF
--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -84,7 +84,6 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                                 Decoration.replace({
                                     widget: new InlineFieldWidget(
                                         app,
-                                        start,
                                         field,
                                         file.path,
                                         this.component,
@@ -167,7 +166,6 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                                 value: Decoration.replace({
                                     widget: new InlineFieldWidget(
                                         app,
-                                        start,
                                         field,
                                         file.path,
                                         this.component,
@@ -190,7 +188,6 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
 class InlineFieldWidget extends WidgetType {
     constructor(
         public app: App,
-        public start: number,
         public field: InlineField,
         public sourcePath: string,
         public parentComponent: Component,
@@ -236,8 +233,8 @@ class InlineFieldWidget extends WidgetType {
                 false
             );
 
-            this.addKeyClickHandlerr(key);
-            this.addValueClickHandlerr(value);
+            this.addKeyClickHandlerr(key, renderContainer);
+            this.addValueClickHandlerr(value, renderContainer);
         } else {
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-standalone-value"],
@@ -250,7 +247,7 @@ class InlineFieldWidget extends WidgetType {
                 this.settings,
                 false
             );
-            this.addValueClickHandlerr(value);
+            this.addValueClickHandlerr(value, renderContainer);
         }
 
         return renderContainer;
@@ -258,26 +255,28 @@ class InlineFieldWidget extends WidgetType {
 
     // https://github.com/blacksmithgu/obsidian-dataview/issues/2101
     // When the user clicks on a rendered inline field, move the cursor to the clicked position.
-    addKeyClickHandlerr(key: HTMLElement) {
+    addKeyClickHandlerr(key: HTMLElement, renderContainer: HTMLElement) {
         key.addEventListener("click", event => {
             if (event instanceof MouseEvent) {
                 const rect = key.getBoundingClientRect();
                 const relativePos = (event.x - rect.x) / rect.width;
+                const startPos = this.view.posAtCoords(renderContainer.getBoundingClientRect(), false);
                 const clickedPos = Math.round(
-                    this.start + (this.field.startValue - 2 - this.field.start) * relativePos
+                    startPos + (this.field.startValue - 2 - this.field.start) * relativePos
                 ); // 2 is the length of "::"
                 this.view.dispatch({ selection: { anchor: clickedPos } });
             }
         });
     }
 
-    addValueClickHandlerr(value: HTMLElement) {
+    addValueClickHandlerr(value: HTMLElement, renderContainer: HTMLElement) {
         value.addEventListener("click", event => {
             if (event instanceof MouseEvent) {
                 const rect = value.getBoundingClientRect();
                 const relativePos = (event.x - rect.x) / rect.width;
+                const startPos = this.view.posAtCoords(renderContainer.getBoundingClientRect(), false);
                 const clickedPos = Math.round(
-                    this.start +
+                    startPos +
                         (this.field.startValue - this.field.start) +
                         (this.field.end - this.field.startValue) * relativePos
                 );

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -82,7 +82,15 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                                 start,
                                 end,
                                 Decoration.replace({
-                                    widget: new InlineFieldWidget(app, start, field, file.path, this.component, settings, view),
+                                    widget: new InlineFieldWidget(
+                                        app,
+                                        start,
+                                        field,
+                                        file.path,
+                                        this.component,
+                                        settings,
+                                        view
+                                    ),
                                 })
                             );
                         }
@@ -157,7 +165,15 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                                 from: start,
                                 to: end,
                                 value: Decoration.replace({
-                                    widget: new InlineFieldWidget(app, start, field, file.path, this.component, settings, view),
+                                    widget: new InlineFieldWidget(
+                                        app,
+                                        start,
+                                        field,
+                                        file.path,
+                                        this.component,
+                                        settings,
+                                        view
+                                    ),
                                 }),
                             },
                         ],
@@ -222,7 +238,6 @@ class InlineFieldWidget extends WidgetType {
 
             this.addKeyClickHandlerr(key);
             this.addValueClickHandlerr(value);
-
         } else {
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-standalone-value"],
@@ -244,22 +259,28 @@ class InlineFieldWidget extends WidgetType {
     // https://github.com/blacksmithgu/obsidian-dataview/issues/2101
     // When the user clicks on a rendered inline field, move the cursor to the clicked position.
     addKeyClickHandlerr(key: HTMLElement) {
-        key.addEventListener("click", (event) => {
+        key.addEventListener("click", event => {
             if (event instanceof MouseEvent) {
                 const rect = key.getBoundingClientRect();
                 const relativePos = (event.x - rect.x) / rect.width;
-                const clickedPos = Math.round(this.start + (this.field.startValue - 2 - this.field.start) * relativePos); // 2 is the length of "::"
+                const clickedPos = Math.round(
+                    this.start + (this.field.startValue - 2 - this.field.start) * relativePos
+                ); // 2 is the length of "::"
                 this.view.dispatch({ selection: { anchor: clickedPos } });
             }
         });
     }
 
     addValueClickHandlerr(value: HTMLElement) {
-        value.addEventListener("click", (event) => {
+        value.addEventListener("click", event => {
             if (event instanceof MouseEvent) {
                 const rect = value.getBoundingClientRect();
                 const relativePos = (event.x - rect.x) / rect.width;
-                const clickedPos = Math.round(this.start + (this.field.startValue - this.field.start) + (this.field.end - this.field.startValue) * relativePos);
+                const clickedPos = Math.round(
+                    this.start +
+                        (this.field.startValue - this.field.start) +
+                        (this.field.end - this.field.startValue) * relativePos
+                );
                 this.view.dispatch({ selection: { anchor: clickedPos } });
             }
         });

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -82,7 +82,7 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                                 start,
                                 end,
                                 Decoration.replace({
-                                    widget: new InlineFieldWidget(app, field, file.path, this.component, settings, view),
+                                    widget: new InlineFieldWidget(app, start, field, file.path, this.component, settings, view),
                                 })
                             );
                         }
@@ -157,7 +157,7 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                                 from: start,
                                 to: end,
                                 value: Decoration.replace({
-                                    widget: new InlineFieldWidget(app, field, file.path, this.component, settings, view),
+                                    widget: new InlineFieldWidget(app, start, field, file.path, this.component, settings, view),
                                 }),
                             },
                         ],
@@ -174,6 +174,7 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
 class InlineFieldWidget extends WidgetType {
     constructor(
         public app: App,
+        public start: number,
         public field: InlineField,
         public sourcePath: string,
         public parentComponent: Component,
@@ -247,7 +248,7 @@ class InlineFieldWidget extends WidgetType {
             if (event instanceof MouseEvent) {
                 const rect = key.getBoundingClientRect();
                 const relativePos = (event.x - rect.x) / rect.width;
-                const clickedPos = Math.round(this.field.start + (this.field.startValue - 2 - this.field.start) * relativePos); // 2 is the length of "::"
+                const clickedPos = Math.round(this.start + (this.field.startValue - 2 - this.field.start) * relativePos); // 2 is the length of "::"
                 this.view.dispatch({ selection: { anchor: clickedPos } });
             }
         });
@@ -258,7 +259,7 @@ class InlineFieldWidget extends WidgetType {
             if (event instanceof MouseEvent) {
                 const rect = value.getBoundingClientRect();
                 const relativePos = (event.x - rect.x) / rect.width;
-                const clickedPos = Math.round(this.field.startValue + (this.field.end - this.field.startValue) * relativePos);
+                const clickedPos = Math.round(this.start + (this.field.startValue - this.field.start) + (this.field.end - this.field.startValue) * relativePos);
                 this.view.dispatch({ selection: { anchor: clickedPos } });
             }
         });

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -261,9 +261,7 @@ class InlineFieldWidget extends WidgetType {
                 const rect = key.getBoundingClientRect();
                 const relativePos = (event.x - rect.x) / rect.width;
                 const startPos = this.view.posAtCoords(renderContainer.getBoundingClientRect(), false);
-                const clickedPos = Math.round(
-                    startPos + (this.field.startValue - 2 - this.field.start) * relativePos
-                ); // 2 is the length of "::"
+                const clickedPos = Math.round(startPos + (this.field.startValue - 2 - this.field.start) * relativePos); // 2 is the length of "::"
                 this.view.dispatch({ selection: { anchor: clickedPos } });
             }
         });

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -233,8 +233,8 @@ class InlineFieldWidget extends WidgetType {
                 false
             );
 
-            this.addKeyClickHandlerr(key, renderContainer);
-            this.addValueClickHandlerr(value, renderContainer);
+            this.addKeyClickHandler(key, renderContainer);
+            this.addValueClickHandler(value, renderContainer);
         } else {
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-standalone-value"],
@@ -247,7 +247,7 @@ class InlineFieldWidget extends WidgetType {
                 this.settings,
                 false
             );
-            this.addValueClickHandlerr(value, renderContainer);
+            this.addValueClickHandler(value, renderContainer);
         }
 
         return renderContainer;
@@ -255,7 +255,7 @@ class InlineFieldWidget extends WidgetType {
 
     // https://github.com/blacksmithgu/obsidian-dataview/issues/2101
     // When the user clicks on a rendered inline field, move the cursor to the clicked position.
-    addKeyClickHandlerr(key: HTMLElement, renderContainer: HTMLElement) {
+    addKeyClickHandler(key: HTMLElement, renderContainer: HTMLElement) {
         key.addEventListener("click", event => {
             if (event instanceof MouseEvent) {
                 const rect = key.getBoundingClientRect();
@@ -267,7 +267,7 @@ class InlineFieldWidget extends WidgetType {
         });
     }
 
-    addValueClickHandlerr(value: HTMLElement, renderContainer: HTMLElement) {
+    addValueClickHandler(value: HTMLElement, renderContainer: HTMLElement) {
         value.addEventListener("click", event => {
             if (event instanceof MouseEvent) {
                 const rect = value.getBoundingClientRect();


### PR DESCRIPTION
This PR resolves #2101.

I'm not sure the current approach is the best one, but in my test, it works well at least for plain text (i.e. without inline markdown formatting syntaxes) fields.

Plain text:

https://github.com/blacksmithgu/obsidian-dataview/assets/72342591/98c4e989-c99f-4e30-a93e-7a96ad24f8e1

Bold:

https://github.com/blacksmithgu/obsidian-dataview/assets/72342591/55c806ec-1e3a-4fe3-af54-f887120aac78

Let me know if anyone has suggestions. Thank you!
