### PR TITLE
Fix #2107: Prevent inline fields inside a code block from being rendered in live preview

### DIFF
--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -14,6 +14,7 @@ import { canonicalizeVarName } from "util/normalize";
 import { renderCompactMarkdown, renderValue } from "ui/render";
 import { DataviewSettings } from "settings";
 import { selectionAndRangeOverlap } from "ui/lp-render";
+import { syntaxTree } from "@codemirror/language";
 
 class InlineFieldValue extends RangeValue {
     constructor(public field: InlineField) {
@@ -27,12 +28,27 @@ class InlineFieldValue extends RangeValue {
 
 function buildInlineFields(state: EditorState): RangeSet<InlineFieldValue> {
     const builder = new RangeSetBuilder<InlineFieldValue>();
+    const tree = syntaxTree(state);
 
     for (let lineNumber = 1; lineNumber <= state.doc.lines; lineNumber++) {
         const line = state.doc.line(lineNumber);
-        const inlineFields = extractInlineFields(line.text);
-        for (const field of inlineFields) {
-            builder.add(line.from + field.start, line.from + field.end, new InlineFieldValue(field));
+        let isInsideCodeBlock = false;
+        tree.iterate({
+            from: line.from,
+            to: line.to,
+            enter: node => {
+                // ignore code blocks
+                if (node.name.startsWith("HyperMD-codeblock")) {
+                    isInsideCodeBlock = true;
+                }
+                return node.name == "Document";
+            },
+        });
+        if (!isInsideCodeBlock) {
+            const inlineFields = extractInlineFields(line.text);
+            for (const field of inlineFields) {
+                builder.add(line.from + field.start, line.from + field.end, new InlineFieldValue(field));
+            }
         }
     }
     return builder.finish();
@@ -77,7 +93,7 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                 for (const { from, to } of view.visibleRanges) {
                     info.between(from, to, (start, end, { field }) => {
                         // If the inline field is not overlapping with the cursor, we replace it with a widget.
-                        if (selectionAndRangeOverlap(selection, start, end)) {
+                        if (!selectionAndRangeOverlap(selection, start, end)) {
                             builder.add(
                                 start,
                                 end,


### PR DESCRIPTION
This PR fixes #2107.

Currently, inline fields inside a code block are
- not rendered in reading view
- but rendered in live preview.

This PR makes the behavior in live preview match with that in reading view.