### PR TITLE
Separate the inline fields rendering option into one for reading view & one for live preview

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -333,12 +333,12 @@ class GeneralSettingsTab extends PluginSettingTab {
             .setName("Enable Inline Field Highlighting in Reading View")
             .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields in Reading View.")
             .addToggle(toggle =>
-                toggle.setValue(this.plugin.settings.prettyRenderInlineFields).onChange(async value => 
-                    await this.plugin.updateSettings({ prettyRenderInlineFields: value })
-                )
+                toggle
+                    .setValue(this.plugin.settings.prettyRenderInlineFields)
+                    .onChange(async value => await this.plugin.updateSettings({ prettyRenderInlineFields: value }))
             );
 
-            new Setting(this.containerEl)
+        new Setting(this.containerEl)
             .setName("Enable Inline Field Highlighting in Live Preview")
             .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields in Live Preview.")
             .addToggle(toggle =>

--- a/src/main.ts
+++ b/src/main.ts
@@ -186,7 +186,7 @@ export default class DataviewPlugin extends Plugin {
         // editor extension for inline queries: enabled regardless of settings (enableInlineDataview/enableInlineDataviewJS)
         this.cmExtension.push(inlinePlugin(this.app, this.index, this.settings, this.api));
         // editor extension for rendering inline fields in live preview
-        if (this.settings.prettyRenderInlineFields) {
+        if (this.settings.prettyRenderInlineFieldsInLivePreview) {
             this.cmExtension.push(inlineFieldsField, replaceInlineFieldsInLivePreview(this.app, this.settings));
         }
         this.app.workspace.updateOptions();
@@ -330,11 +330,20 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Enable Inline Field Highlighting")
-            .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields.")
+            .setName("Enable Inline Field Highlighting in Reading View")
+            .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields in Reading View.")
             .addToggle(toggle =>
-                toggle.setValue(this.plugin.settings.prettyRenderInlineFields).onChange(async value => {
-                    await this.plugin.updateSettings({ prettyRenderInlineFields: value });
+                toggle.setValue(this.plugin.settings.prettyRenderInlineFields).onChange(async value => 
+                    await this.plugin.updateSettings({ prettyRenderInlineFields: value })
+                )
+            );
+
+            new Setting(this.containerEl)
+            .setName("Enable Inline Field Highlighting in Live Preview")
+            .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields in Live Preview.")
+            .addToggle(toggle =>
+                toggle.setValue(this.plugin.settings.prettyRenderInlineFieldsInLivePreview).onChange(async value => {
+                    await this.plugin.updateSettings({ prettyRenderInlineFieldsInLivePreview: value });
                     this.plugin.updateEditorExtensions();
                 })
             );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -84,8 +84,10 @@ export interface DataviewSettings extends QuerySettings, ExportSettings {
     enableInlineDataview: boolean;
     /** Enable or disable executing inline DataviewJS queries. */
     enableInlineDataviewJs: boolean;
-    /** Enable or disable rendering inline fields prettily. */
+    /** Enable or disable rendering inline fields prettily in Reading View. */
     prettyRenderInlineFields: boolean;
+    /** Enable or disable rendering inline fields prettily in Live Preview. */
+    prettyRenderInlineFieldsInLivePreview: boolean;
     /** The keyword for DataviewJS blocks. */
     dataviewJsKeyword: string;
 }
@@ -102,6 +104,7 @@ export const DEFAULT_SETTINGS: DataviewSettings = {
         enableDataviewJs: false,
         enableInlineDataviewJs: false,
         prettyRenderInlineFields: true,
+        prettyRenderInlineFieldsInLivePreview: true,
         dataviewJsKeyword: "dataviewjs",
     },
 };


### PR DESCRIPTION
I realized there are many users feeling uncomfortable with the new inline fields rendering feature in Live Preview.

So I proposed to separate the current "Enable Inline Field Highlighting" option into one for Reading View and another for Live Preview. This way, users can choose between enabling it both in Live Preview and enabling it only in Reading View like in good old days.

(I'm sorry for the inconvenience introduced by the feature I implemented in #2083.)