### PR TITLE
Modify `renderCompactMarkdown()` so that it causes no flickering/scrolling in Live Preview

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -186,7 +186,7 @@ export default class DataviewPlugin extends Plugin {
         // editor extension for inline queries: enabled regardless of settings (enableInlineDataview/enableInlineDataviewJS)
         this.cmExtension.push(inlinePlugin(this.app, this.index, this.settings, this.api));
         // editor extension for rendering inline fields in live preview
-        if (this.settings.prettyRenderInlineFields) {
+        if (this.settings.prettyRenderInlineFieldsInLivePreview) {
             this.cmExtension.push(inlineFieldsField, replaceInlineFieldsInLivePreview(this.app, this.settings));
         }
         this.app.workspace.updateOptions();
@@ -330,11 +330,20 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Enable Inline Field Highlighting")
-            .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields.")
+            .setName("Enable Inline Field Highlighting in Reading View")
+            .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields in Reading View.")
             .addToggle(toggle =>
-                toggle.setValue(this.plugin.settings.prettyRenderInlineFields).onChange(async value => {
-                    await this.plugin.updateSettings({ prettyRenderInlineFields: value });
+                toggle
+                    .setValue(this.plugin.settings.prettyRenderInlineFields)
+                    .onChange(async value => await this.plugin.updateSettings({ prettyRenderInlineFields: value }))
+            );
+
+        new Setting(this.containerEl)
+            .setName("Enable Inline Field Highlighting in Live Preview")
+            .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields in Live Preview.")
+            .addToggle(toggle =>
+                toggle.setValue(this.plugin.settings.prettyRenderInlineFieldsInLivePreview).onChange(async value => {
+                    await this.plugin.updateSettings({ prettyRenderInlineFieldsInLivePreview: value });
                     this.plugin.updateEditorExtensions();
                 })
             );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -84,8 +84,10 @@ export interface DataviewSettings extends QuerySettings, ExportSettings {
     enableInlineDataview: boolean;
     /** Enable or disable executing inline DataviewJS queries. */
     enableInlineDataviewJs: boolean;
-    /** Enable or disable rendering inline fields prettily. */
+    /** Enable or disable rendering inline fields prettily in Reading View. */
     prettyRenderInlineFields: boolean;
+    /** Enable or disable rendering inline fields prettily in Live Preview. */
+    prettyRenderInlineFieldsInLivePreview: boolean;
     /** The keyword for DataviewJS blocks. */
     dataviewJsKeyword: string;
 }
@@ -102,6 +104,7 @@ export const DEFAULT_SETTINGS: DataviewSettings = {
         enableDataviewJs: false,
         enableInlineDataviewJs: false,
         prettyRenderInlineFields: true,
+        prettyRenderInlineFieldsInLivePreview: true,
         dataviewJsKeyword: "dataviewjs",
     },
 };

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -196,7 +196,13 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                     exists = true;
                 });
                 if (!exists) {
-                    const currentFile = app.workspace.getActiveFile();
+                    /**
+                     * In a note embedded in a Canvas, app.workspace.getActiveFile() returns
+                     * the canvas file, not the note file. On the other hand,
+                     * view.state.field(editorInfoField).file returns the note file itself,
+                     * which is more suitable here.
+                     */
+                    const currentFile = view.state.field(editorInfoField).file;
                     if (!currentFile) return;
                     const newDeco = this.renderWidget(node, view, currentFile)?.value;
                     if (newDeco) {
@@ -243,7 +249,7 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
             inlineRender(view: EditorView) {
                 // still doesn't work as expected for tables and callouts
                 if (!index.initialized) return;
-                const currentFile = app.workspace.getActiveFile();
+                const currentFile = view.state.field(editorInfoField).file;
                 if (!currentFile) return;
 
                 const widgets: Range<Decoration>[] = [];

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -26,7 +26,7 @@ export async function renderCompactMarkdown(
          * dv.paragraph(`
          * - list item 1
          * - list item 2
-         * 
+         *
          * 1. list item 3
          * 2. list item 4
          * `)

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -12,15 +12,16 @@ export async function renderCompactMarkdown(
     sourcePath: string,
     component: Component
 ) {
-    const tmpContainer = createSpan();
-    await MarkdownRenderer.renderMarkdown(markdown, tmpContainer, sourcePath, component);
+    let subcontainer = container.createSpan();
+    await MarkdownRenderer.renderMarkdown(markdown, subcontainer, sourcePath, component);
 
-    let paragraph = tmpContainer.querySelector(":scope > p");
-    if (tmpContainer.childNodes.length == 1 && paragraph) {
-        container.replaceChildren(...paragraph.childNodes);
+    let paragraph = subcontainer.querySelector(":scope > p");
+    if (subcontainer.children.length == 1 && paragraph) {
+        while (paragraph.firstChild) {
+            subcontainer.appendChild(paragraph.firstChild);
+        }
+        subcontainer.removeChild(paragraph);
     }
-
-    tmpContainer.remove();
 }
 
 /** Render a pre block with an error in it; returns the element to allow for dynamic updating. */

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -82,7 +82,14 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                                 start,
                                 end,
                                 Decoration.replace({
-                                    widget: new InlineFieldWidget(app, field, file.path, this.component, settings),
+                                    widget: new InlineFieldWidget(
+                                        app,
+                                        field,
+                                        file.path,
+                                        this.component,
+                                        settings,
+                                        view
+                                    ),
                                 })
                             );
                         }
@@ -129,7 +136,7 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                             this.removeDeco(start, end);
                             return;
                         } else {
-                            this.addDeco(start, end, field, file);
+                            this.addDeco(start, end, field, file, view);
                         }
                     });
                 }
@@ -145,7 +152,7 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                 });
             }
 
-            addDeco(start: number, end: number, field: InlineField, file: TFile) {
+            addDeco(start: number, end: number, field: InlineField, file: TFile, view: EditorView) {
                 let exists = false;
                 this.decorations.between(start, end, () => {
                     exists = true;
@@ -157,7 +164,14 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                                 from: start,
                                 to: end,
                                 value: Decoration.replace({
-                                    widget: new InlineFieldWidget(app, field, file.path, this.component, settings),
+                                    widget: new InlineFieldWidget(
+                                        app,
+                                        field,
+                                        file.path,
+                                        this.component,
+                                        settings,
+                                        view
+                                    ),
                                 }),
                             },
                         ],
@@ -177,7 +191,8 @@ class InlineFieldWidget extends WidgetType {
         public field: InlineField,
         public sourcePath: string,
         public parentComponent: Component,
-        public settings: DataviewSettings
+        public settings: DataviewSettings,
+        public view: EditorView
     ) {
         super();
     }
@@ -217,6 +232,9 @@ class InlineFieldWidget extends WidgetType {
                 this.settings,
                 false
             );
+
+            this.addKeyClickHandler(key, renderContainer);
+            this.addValueClickHandler(value, renderContainer);
         } else {
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-standalone-value"],
@@ -229,9 +247,40 @@ class InlineFieldWidget extends WidgetType {
                 this.settings,
                 false
             );
+            this.addValueClickHandler(value, renderContainer);
         }
 
         return renderContainer;
+    }
+
+    // https://github.com/blacksmithgu/obsidian-dataview/issues/2101
+    // When the user clicks on a rendered inline field, move the cursor to the clicked position.
+    addKeyClickHandler(key: HTMLElement, renderContainer: HTMLElement) {
+        key.addEventListener("click", event => {
+            if (event instanceof MouseEvent) {
+                const rect = key.getBoundingClientRect();
+                const relativePos = (event.x - rect.x) / rect.width;
+                const startPos = this.view.posAtCoords(renderContainer.getBoundingClientRect(), false);
+                const clickedPos = Math.round(startPos + (this.field.startValue - 2 - this.field.start) * relativePos); // 2 is the length of "::"
+                this.view.dispatch({ selection: { anchor: clickedPos } });
+            }
+        });
+    }
+
+    addValueClickHandler(value: HTMLElement, renderContainer: HTMLElement) {
+        value.addEventListener("click", event => {
+            if (event instanceof MouseEvent) {
+                const rect = value.getBoundingClientRect();
+                const relativePos = (event.x - rect.x) / rect.width;
+                const startPos = this.view.posAtCoords(renderContainer.getBoundingClientRect(), false);
+                const clickedPos = Math.round(
+                    startPos +
+                        (this.field.startValue - this.field.start) +
+                        (this.field.end - this.field.startValue) * relativePos
+                );
+                this.view.dispatch({ selection: { anchor: clickedPos } });
+            }
+        });
     }
 }
 

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -77,7 +77,7 @@ export const replaceInlineFieldsInLivePreview = (app: App, settings: DataviewSet
                 for (const { from, to } of view.visibleRanges) {
                     info.between(from, to, (start, end, { field }) => {
                         // If the inline field is not overlapping with the cursor, we replace it with a widget.
-                        if (selectionAndRangeOverlap(selection, start, end)) {
+                        if (!selectionAndRangeOverlap(selection, start, end)) {
                             builder.add(
                                 start,
                                 end,


### PR DESCRIPTION
As reported in #2128 and #2129, inline fields causes force-scrolling and flickering in Live Preview under some circumstances.

In my current understanding, the root cause resides in the `renderCompactMarkdown()` function. I'm not completely sure, but it seems that the previous implementation of this function (which has existed since before 0.5.60) caused vertical movement/flickering that leads to the force-scrolling issue. The problem was `container.createSpan`, which creates `<span>` in the DOM structure before its child nodes are extracted from the `<p>` container.

https://github.com/blacksmithgu/obsidian-dataview/blob/6896a1a9574fcd900f1c8831b48a1d32db214c0e/src/ui/render.ts#L8-L25

In this PR, I replaced `container.createSpan` with `createSpan`, preventing the `subcontainer`/`tmpContainer` being added as a child of `container` at this point.

In my test, this fixed the issue.

I also replaced the `while` loop with `replaceChildren`, by which I feel the performance has been slightly improved when scrolling the page.

If you have any concerns or suggestions, please let me know. Thank you!