### PR TITLE
Add comments to query language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-dataview",
-  "version": "0.5.61",
+  "version": "0.5.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-dataview",
-      "version": "0.5.61",
+      "version": "0.5.64",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "https://github.com/lishid/cm-language",

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -5,6 +5,9 @@ import { Field } from "expression/field";
 /** The supported query types (corresponding to view types). */
 export type QueryType = "list" | "table" | "task" | "calendar";
 
+/** A single-line comment. */
+export type Comment = string;
+
 /** Fields used in the query portion. */
 export interface NamedField {
     /** The effective name of this field. */


### PR DESCRIPTION
This PR adds comments to DQL. Comments start with `//` and can be on their own line or after another statement.

Resolves #1624 
[[1]](https://github.com/blacksmithgu/obsidian-dataview/issues/1624#issuecomment-1794031757) and [[2]](https://github.com/blacksmithgu/obsidian-dataview/issues/1624#issuecomment-1794031826) are implemented. [[3]](https://github.com/blacksmithgu/obsidian-dataview/issues/1624#issuecomment-1794031826) can be performed by creating multiple single-line comments.

Example:
```
// This is a comment at the beginning
TABLE (time-played + 100) as long, rating as rate, length
// This is a comment
// This is a second comment
FROM #games or #gaming  // This is an inline comment
// This is a third comment
WHERE long > 150 and rate - 10 < 40
// This is a fourth comment

   // This is a comment with whitespace prior
SORT length + 8 + 4 DESCENDING, long ASC
// This is a comment at the end
```