### PR TITLE
`dv.taskList`: fix mismatching documentation and behaviour for `groupByFiles`

### DIFF
--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -516,7 +516,7 @@ export class DataviewApi {
     /** Render a dataview task view with the given tasks. */
     public async taskList(
         tasks: Grouping<SListItem>,
-        groupByFile: boolean = true,
+        groupByFile: boolean = false,
         container: HTMLElement,
         component: Component,
         filePath: string = ""


### PR DESCRIPTION
I spotted this mismatch in the docs and the code and decided it'd be easier to just fix it than raise an issue.

# Problem

The [current documentation](https://blacksmithgu.github.io/obsidian-dataview/api/code-reference/#dvtasklisttasks-groupbyfile) for 0.5.64 states:

> Render a dataview list of Task objects, as obtained by page.file.tasks. Only the first argument is required; **if the second argument groupByFile is provided (and is true)**, then tasks will be grouped by the file they come from automatically.

However, this is untrue. The following query results in the following rendered task list:

````
```dataviewjs
dv.taskList(dv.current().file.tasks)
```
````

<img width="888" alt="image" src="https://github.com/blacksmithgu/obsidian-dataview/assets/28042291/a645343a-ae17-4df3-8107-65c68e30b581">

# Solution

Change the default for `groupByFiles` to false to bring it in line with the documentation.

Alternatively, you could update the documentation to state:

> Render a dataview list of Task objects, as obtained by page.file.tasks. Only the first argument is required; **if the second argument groupByFile is provided (and is false)**, then tasks will be displayed in one list without separation under a header with their respective files' names.