### PR TITLE
✏ Fix some semantic, grammatical errors & typos in Task metadata docs

### DIFF
--- a/docs/docs/annotation/metadata-tasks.md
+++ b/docs/docs/annotation/metadata-tasks.md
@@ -57,20 +57,20 @@ As with pages, Dataview adds a number of implicit fields to each task or list it
 
 | Field name | Data Type | Description |
 | ---------- | --------- | ----------- |
-| `status` |  Text | The completion status of this task, as determined by the character inside the `[ ]` brackets. Generally a space `" "` for incomplete tasks and a `"x"` for complete tasks, but allows for plugins which support alternative task statuses. |
-| `checked` |  Boolean  | Whether or not this task status is empty, meaning it has a space in its `[ ]` brackets |
-| `completed` |  Boolean  | Whether or not this *specific* task has been completed; this does not consider the completionnon-completion of any child tasks. A task is explicitly considered "completed" if it has been marked with an 'x'. If you use a custom status, i.e. `[-]`, `checked` will be true, whereas `completed` will be false. |
+| `status` |  Text | The completion status of this task, as determined by the character inside the `[ ]` brackets. Generally a space `" "` for incomplete tasks and an `"x"` for completed tasks, but allows for plugins which support alternative task statuses. |
+| `checked` |  Boolean  | Whether or not this task's status is **not** empty, meaning it has some `status` character (which may or may not be `"x"`) instead of a space in its `[ ]` brackets. |
+| `completed` |  Boolean  | Whether or not this *specific* task has been completed; this does not consider the completion or non-completion of any child tasks. A task is explicitly considered "completed" if it has been marked with an `"x"`. If you use a custom status, e.g. `[-]`, `checked` will be true, whereas `completed` will be false. |
 | `fullyCompleted` |  Boolean  | Whether or not this task and **all** of its subtasks are completed. |
 | `text` |  Text  | The plain text of this task, including any metadata field annotations. |
 | `visual` | Text | The text of this task, which is rendered by Dataview. It can be modified to render arbitrary text. |
 | `line` |  Number  | The line of the file this task shows up on. |
 | `lineCount` |  Number  | The number of Markdown lines that this task takes up. |
-| `path` |  Text  | The full path of the file this task is in. Equals to `file.path` for [pages](./metadata-pages.md) |
-| `section` | Link |  link to the section this task is contained in. |
-| `tags` | List  | Any tags inside of the text task. |
+| `path` |  Text  | The full path of the file this task is in. Equals to `file.path` for [pages](./metadata-pages.md). |
+| `section` | Link |  Link to the section this task is contained in. |
+| `tags` | List  | Any tags inside the task text. |
 | `outlinks` | List |  Any links defined in this task. |
-| `link` | Link  |  link to the closest linkable block near this task; useful for making links which go to the task. |
-| `children` | List  | ny subtasks or sublists of this task. |
+| `link` | Link  |  Link to the closest linkable block near this task; useful for making links which go to the task. |
+| `children` | List  | Any subtasks or sublists of this task. |
 | `task` | Boolean  | If true, this is a task; otherwise, it is a regular list element. |
 | `annotated` | Boolean  | True if the task text contains any metadata fields, false otherwise. |
 | `parent` | Number |  The line number of the task above this task, if present; will be null if this is a root-level task. |
@@ -84,7 +84,7 @@ With usage of the [shorthand syntax](#field-shorthands), following additional pr
 - `start`: The date a task can be started.
 - `scheduled`: The date a task is scheduled to work on.
 
-### Access of Implicit Fields for List Items and Tasks
+### Accessing Implicit Fields in Queries
 
 If you're using a [TASK](../queries/query-types.md#task-queries) Query, your tasks are the top level information and can be used without any prefix:
 
@@ -95,7 +95,7 @@ WHERE !fullyCompleted
 ```
 ~~~
 
-On every other Query Type, you first need to access the implicit field `file.lists` or `file.tasks` to check for these list item specific implicit fields:
+For every other Query type, you first need to access the implicit field `file.lists` or `file.tasks` to check for these list item specific implicit fields:
 
 ~~~markdown
 ```dataview
@@ -104,4 +104,4 @@ WHERE any(file.tasks, (t) => !t.fullyCompleted)
 ```
 ~~~
 
-This'll give you back all file links that have unfinished tasks inside. We get back a list of tasks on page level and thus need to use a [list function](../reference/functions.md) to look at each element. 
+This will give you back all the file links that have unfinished tasks inside. We get back a list of tasks on page level and thus need to use a [list function](../reference/functions.md) to look at each element. 


### PR DESCRIPTION
- Task implicit field `checked` checks for the presence of any `status` char (including `x`) between the `[ ]` but the documentation states
  > Whether or not this task status is empty, meaning it has a space in its `[ ]` brackets

  which is quite the opposite actually.
- The PR also fixes some other small grammatical errors and typos.