### PR TITLE
Add workaround to refresh issue of #1752

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,7 @@ export default class DataviewPlugin extends Plugin {
                 this.index.reinitialize();
             },
         });
-        
+
         interface WorkspaceLeafRebuild extends WorkspaceLeaf {
             rebuildView(): void;
         }
@@ -131,12 +131,12 @@ export default class DataviewPlugin extends Plugin {
             id: "dataview-rebuild-current-view",
             name: "Rebuild current view",
             callback: () => {
-                const activeView: MarkdownView|null = this.app.workspace.getActiveViewOfType(MarkdownView)
+                const activeView: MarkdownView | null = this.app.workspace.getActiveViewOfType(MarkdownView);
                 if (activeView) {
-                    (activeView.leaf as WorkspaceLeafRebuild).rebuildView()
+                    (activeView.leaf as WorkspaceLeafRebuild).rebuildView();
                 }
-            }
-        })
+            },
+        });
 
         // Run index initialization, which actually traverses the vault to index files.
         if (!this.app.workspace.layoutReady) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
     Plugin,
     PluginSettingTab,
     Setting,
+    WorkspaceLeaf,
 } from "obsidian";
 import { renderErrorPre } from "ui/render";
 import { FullIndex } from "data-index/index";
@@ -121,6 +122,21 @@ export default class DataviewPlugin extends Plugin {
                 this.index.reinitialize();
             },
         });
+        
+        interface WorkspaceLeafRebuild extends WorkspaceLeaf {
+            rebuildView(): void;
+        }
+
+        this.addCommand({
+            id: "dataview-rebuild-current-view",
+            name: "Rebuild current view",
+            callback: () => {
+                const activeView: MarkdownView|null = this.app.workspace.getActiveViewOfType(MarkdownView)
+                if (activeView) {
+                    (activeView.leaf as WorkspaceLeafRebuild).rebuildView()
+                }
+            }
+        })
 
         // Run index initialization, which actually traverses the vault to index files.
         if (!this.app.workspace.layoutReady) {


### PR DESCRIPTION
Adding a command which can circumvent the issues of #1752, #1759, #2228 (and possibly #1075). This command allows for a full re-run of any query on the active page.