### PR TITLE
Add two language for dataview settings: 简体中文、繁體中文

### DIFF
--- a/src/lang/helpers.ts
+++ b/src/lang/helpers.ts
@@ -1,0 +1,59 @@
+//Solution copied from obsidian-excalidraw: https://github.com/zsviczian/obsidian-excalidraw-plugin/blob/master/src/lang/helpers.ts
+
+import { moment } from "obsidian";
+import ar from "./locale/ar";
+import cz from "./locale/cz";
+import da from "./locale/da";
+import de from "./locale/de";
+import en from "./locale/en";
+import enGB from "./locale/en-gb";
+import es from "./locale/es";
+import fr from "./locale/fr";
+import hi from "./locale/hi";
+import id from "./locale/id";
+import it from "./locale/it";
+import ja from "./locale/ja";
+import ko from "./locale/ko";
+import nl from "./locale/nl";
+import no from "./locale/no";
+import pl from "./locale/pl";
+import pt from "./locale/pt";
+import ptBR from "./locale/pt-br";
+import ro from "./locale/ro";
+import ru from "./locale/ru";
+import tr from "./locale/tr";
+import zhCN from "./locale/zh-cn";
+import zhTW from "./locale/zh-tw";
+
+const localeMap: { [k: string]: Partial<typeof en> } = {
+  ar,
+  cs: cz,
+  da,
+  de,
+  en,
+  "en-gb": enGB,
+  es,
+  fr,
+  hi,
+  id,
+  it,
+  ja,
+  ko,
+  nl,
+  nn: no,
+  pl,
+  pt,
+  "pt-br": ptBR,
+  ro,
+  ru,
+  tr,
+  "zh-cn": zhCN,
+  "zh-tw": zhTW,
+};
+
+const locale = localeMap[moment.locale()];
+
+export function t(str: keyof typeof en): string {
+
+  return (locale && locale[str]) || en[str];
+}

--- a/src/lang/locale/ar.ts
+++ b/src/lang/locale/ar.ts
@@ -1,0 +1,3 @@
+// العربية
+
+export default {};

--- a/src/lang/locale/cz.ts
+++ b/src/lang/locale/cz.ts
@@ -1,0 +1,3 @@
+// čeština
+
+export default {};

--- a/src/lang/locale/da.ts
+++ b/src/lang/locale/da.ts
@@ -1,0 +1,3 @@
+// Dansk
+
+export default {};

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -1,0 +1,3 @@
+// Deutsch
+
+export default {};

--- a/src/lang/locale/en-gb.ts
+++ b/src/lang/locale/en-gb.ts
@@ -1,0 +1,3 @@
+// British English
+
+export default {};

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -1,0 +1,98 @@
+export default {
+  // General Settings
+  'General Settings': 'General Settings',
+
+  'Enable Inline Queries': 'Enable Inline Queries',
+  'Description of Enable Inline Queries': 'Enable or disable executing regular inline Dataview queries.',
+
+  'Enable JavaScript Queries': 'Enable JavaScript Queries',
+  'Description of Enable JavaScript Queries': 'Enable or disable executing DataviewJS queries.',
+
+  'Enable Inline JavaScript Queries': 'Enable Inline JavaScript Queries',
+  'Description of Enable Inline JavaScript Queries': 'Enable or disable executing inline DataviewJS queries. Requires that DataviewJS queries are enabled.',
+
+  'Enable Inline Field Highlighting in Reading View': 'Enable Inline Field Highlighting in Reading View',
+  'Description of Enable Inline Field Highlighting in Reading View': 'Enables or disables visual highlighting / pretty rendering for inline fields in Reading View.',
+
+  'Enable Inline Field Highlighting in Live Preview': 'Enable Inline Field Highlighting in Live Preview',
+  'Description of Enable Inline Field Highlighting in Live Preview': 'Enables or disables visual highlighting / pretty rendering for inline fields in Live Preview.',
+
+  // Codeblock Settings
+  'Codeblock Settings': 'Codeblock Settings',
+
+  'DataviewJS Keyword': 'DataviewJS Keyword',
+  "Description of DataviewJS Keyword": "Keyword for DataviewJS blocks. Defaults to 'dataviewjs'. Reload required for changes to take effect.",
+  
+  'Inline Query Prefix': 'Inline Query Prefix',
+  "Description of Inline Query Prefix": "The prefix to inline queries (to mark them as Dataview queries). Defaults to '='.",
+
+  'JavaScript Inline Query Prefix': 'JavaScript Inline Query Prefix',
+  "Description of JavaScript Inline Query Prefix": "The prefix to JavaScript inline queries (to mark them as DataviewJS queries). Defaults to '$='.",
+
+  'Codeblock Inline Queries': 'Codeblock Inline Queries',
+  'Description of Codeblock Inline Queries': 'If enabled, inline queries will also be evaluated inside full codeblocks.',
+
+  // View Settings
+  'View Settings': 'View Settings',
+
+  // General
+  'General': 'General',
+  'Display result count': 'Display result count',
+  'Description of Display result count': 'If toggled off, the small number in the result header of TASK and TABLE Queries will be hidden.',
+  
+  'Warn on Empty Result': 'Warn on Empty Result',
+  'Description of Warn on Empty Result': 'If set, queries which return 0 results will render a warning message.',
+  
+  'Render Null As': 'Render Null As',
+  'Description of Render Null As': 'What null/non-existent should show up as in tables, by default. This supports Markdown notation.',
+  
+  'Automatic View Refreshing': 'Automatic View Refreshing',
+  'Description of Automatic View Refreshing': 'If enabled, views will automatically refresh when files in your vault change; this can negatively affect',
+
+  'Refresh Interval': 'Refresh Interval',
+  'Description of Refresh Interval': 'How long to wait (in milliseconds) for files to stop changing before updating views.',
+
+  'Date Format': 'Date Format',
+  'Description of Date Format': "The default date format (see Luxon date format options)." + " Currently: ",
+  'Onchange Description of Date Format': "The default date format (see Luxon date format options)." + " Currently: ",
+
+  'Date + Time Format': 'Date + Time Format',
+  'Description of Date + Time Format': "The default date and time format (see Luxon date format options)." + " Currently: ",
+  'Onchange Description of Date + Time Format': "The default date and time format (see Luxon date format options)." + " Currently: ",
+
+  // Table Setting
+  "Table Settings": "Table Settings",
+
+  "Primary Column Name": "Primary Column Name",
+  "Description of Primary Column Name": "The name of the default ID column in tables; this is the auto-generated first column that links to the source file.",
+
+  "Grouped Column Name": "Grouped Column Name",
+  "Description of Grouped Column Name": 
+    "The name of the default ID column in tables, when the table is on grouped data; this is the auto-generated first column" +
+    "that links to the source file/group.",
+  
+  // Task Settings
+  "Task Settings": "Task Settings",
+
+  "Automatic Task Completion Tracking": "Automatic Task Completion Tracking",
+  "Description[0] of Automatic Task Completion Tracking": "If enabled, Dataview will automatically append tasks with their completion date when they are checked in Dataview views.",
+  "Description[1] of Automatic Task Completion Tracking": "Example with default field name and date format: - [x] my task [completion:: 2022-01-01]",
+
+  "Use Emoji Shorthand for Completion": "Use Emoji Shorthand for Completion",
+  "Description[0] of Use Emoji Shorthand for Completion": 'If enabled, will use emoji shorthand instead of inline field formatting to fill out implicit task field "completion".',
+  "Description[1] of Use Emoji Shorthand for Completion": "Example: - [x] my task ✅ 2022-01-01",
+  "Description[2] of Use Emoji Shorthand for Completion": "Disable this to customize the completion date format or field name, or to use Dataview inline field formatting.",
+  "Description[3] of Use Emoji Shorthand for Completion": 'Only available when "Automatic Task Completion Tracking" is enabled.',
+
+  "Completion Field Name": "Completion Field Name",
+  "Description[0] of Completion Field Name": "Text used as inline field key for task completion date when toggling a task's checkbox in a dataview view.",
+  "Description[1] of Completion Field Name": 'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.',
+
+  "Completion Date Format": "Completion Date Format",
+  "Description[0] of Completion Date Format": "Date-time format for task completion date when toggling a task's checkbox in a dataview view (see Luxon date format options).",
+  "Description[1] of Completion Date Format": 'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.',
+  "Description[2] of Completion Date Format": "Currently: ",
+
+  "Recursive Sub-Task Completion": "Recursive Sub-Task Completion",
+  "Description of Recursive Sub-Task Completion": "If enabled, completing a task in a DataView will automatically complete its subtasks too.",
+};

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -1,0 +1,3 @@
+// Español
+
+export default {};

--- a/src/lang/locale/fr.ts
+++ b/src/lang/locale/fr.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/src/lang/locale/hi.ts
+++ b/src/lang/locale/hi.ts
@@ -1,0 +1,3 @@
+// हिन्दी
+
+export default {};

--- a/src/lang/locale/id.ts
+++ b/src/lang/locale/id.ts
@@ -1,0 +1,3 @@
+// Bahasa Indonesia
+
+export default {};

--- a/src/lang/locale/it.ts
+++ b/src/lang/locale/it.ts
@@ -1,0 +1,3 @@
+// Italiano
+
+export default {};

--- a/src/lang/locale/ja.ts
+++ b/src/lang/locale/ja.ts
@@ -1,0 +1,3 @@
+// 日本語
+
+export default {};

--- a/src/lang/locale/ko.ts
+++ b/src/lang/locale/ko.ts
@@ -1,0 +1,3 @@
+// 한국어
+
+export default {};

--- a/src/lang/locale/nl.ts
+++ b/src/lang/locale/nl.ts
@@ -1,0 +1,3 @@
+// Nederlands
+
+export default {};

--- a/src/lang/locale/no.ts
+++ b/src/lang/locale/no.ts
@@ -1,0 +1,3 @@
+// Norsk
+
+export default {};

--- a/src/lang/locale/pl.ts
+++ b/src/lang/locale/pl.ts
@@ -1,0 +1,3 @@
+// język polski
+
+export default {};

--- a/src/lang/locale/pt-br.ts
+++ b/src/lang/locale/pt-br.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/src/lang/locale/pt.ts
+++ b/src/lang/locale/pt.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/src/lang/locale/ro.ts
+++ b/src/lang/locale/ro.ts
@@ -1,0 +1,3 @@
+// Română
+
+export default {};

--- a/src/lang/locale/ru.ts
+++ b/src/lang/locale/ru.ts
@@ -1,0 +1,3 @@
+// русский
+
+export default {};

--- a/src/lang/locale/tr.ts
+++ b/src/lang/locale/tr.ts
@@ -1,0 +1,3 @@
+// Türkçe
+
+export default {};

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -1,0 +1,96 @@
+export default {
+  // General Settings
+  'General Settings': '常规设置',
+
+  'Enable Inline Queries': '启用行内查询',
+  'Description of Enable Inline Queries': '启用或禁用执行常规 Dataview 行内查询',
+
+  'Enable JavaScript Queries': '启用 JavaScript 查询',
+  'Description of Enable JavaScript Queries': '启用或禁用执行 DataviewJS 查询',
+
+  'Enable Inline JavaScript Queries': '启用行内 JavaScript 查询',
+  'Description of Enable Inline JavaScript Queries': '启用或禁用执行行内 DataviewJS 查询。需要启用 DataviewJS 查询',
+
+  'Enable Inline Field Highlighting in Reading View': '在阅读视图中高亮行内字段',
+  'Description of Enable Inline Field Highlighting in Reading View': '在阅读视图中，启用或禁用行内字段的渲染。',
+
+  'Enable Inline Field Highlighting in Live Preview': '在实时预览中高亮行内字段',
+  'Description of Enable Inline Field Highlighting in Live Preview': '在实时预览中，启用或禁用行内字段的渲染。',
+
+  // Codeblock Settings
+  'Codeblock Settings': '代码块设置',
+
+  'DataviewJS Keyword': 'DataviewJS 关键字',
+  "Description of DataviewJS Keyword": "DataviewJS 代码块的关键字. 默认是 'dataviewjs'. 需要重启 Obsidian 才能生效.",
+
+  'Inline Query Prefix': '行内查询的前缀',
+  "Description of Inline Query Prefix": "行内查询的前缀 (用来标识 Dataview 查询)，默认为 '='。",
+
+  'JavaScript Inline Query Prefix': 'JavaScript 行内查询的前缀',
+  "Description of JavaScript Inline Query Prefix": "JavaScript 行内查询的前缀 (用来标识 DataviewJS 查询)，默认为 '$='.",
+
+  'Codeblock Inline Queries': '代码块行内查询',
+  'Description of Codeblock Inline Queries': '如果启用，行内查询也可以在代码块查询中生效',
+
+  // View Settings
+  'View Settings': '视图设置',
+
+  // General
+  'General': '常规',
+  'Display result count': '显示结果数量',
+  'Description of Display result count': '如果关闭，TASK 和 TABLE 查询结果开头处的小数字将被隐藏。',
+
+  'Warn on Empty Result': '空结果警告',
+  'Description of Warn on Empty Result': '如果设置，查询到 0 个结果的查询将会变为警告消息',
+
+  'Render Null As': '空值渲染为',
+  'Description of Render Null As': '默认情况下，表中应该显示 null 以及不存在的内容。支持 Markdown 语法',
+
+  'Automatic View Refreshing': '自动刷新视图',
+  'Description of Automatic View Refreshing': '如果启用，当库中的文件更改时，视图将自动刷新。这会产生负面影响',
+
+  'Refresh Interval': '刷新间隔',
+  'Description of Refresh Interval': '文件更改完成后，需要等待多长时间再更新视图 (单位: 毫秒)',
+
+  'Date Format': '日期格式',
+  'Description of Date Format': "默认日期的格式 (参见 Luxon 日期格式)" + " 当前: ",
+  'Onchage Description of Date Format': "默认日期的格式(参见 Luxon 日期格式)" + " 当前: ",
+
+  'Date + Time Format': '日期 + 时间格式',
+  'Description of Date + Time Format': "默认的日期和时间的格式 (参见 Luxon 日期格式)" + " 当前: ",
+  'Onchage Description of Date + Time Format': "默认的日期和时间的格式(参见 Luxon 日期格式)" + " 当前: ",
+
+  // Table Setting
+  "Table Settings": "表格视图设置",
+
+  "Primary Column Name": "主列名称",
+  "Description of Primary Column Name": "表格自动生成的第一列默认的 ID 的名称。内容为链接到源文件的链接。",
+
+  "Grouped Column Name": "成组的列的名称",
+  "Description of Grouped Column Name": "指当表格有内容成组后，表格自动生成的第一列的默认 ID 的名称。内容为链接到源文件的链接。",
+
+  // Task Settings
+  "Task Settings": "任务视图设置",
+
+  "Automatic Task Completion Tracking": "自动任务完成跟踪",
+  "Description[0] of Automatic Task Completion Tracking": "如果启用，当在 Dataview 查询结果中点击完成任务时，Dataview 将自动给任务附加及其完成日期。",
+  "Description[1] of Automatic Task Completion Tracking": "用默认字段和默认日期格式举例: - [x] 我的任务 [completion:: 2022-01-01]",
+
+  "Use Emoji Shorthand for Completion": "完成时用 Emoji 简写",
+  "Description[0] of Use Emoji Shorthand for Completion": '如果启用，将使用 emoji 简写替代行内任务字段 "completion".',
+  "Description[1] of Use Emoji Shorthand for Completion": "例子: - [x] 我的任务 ✅ 2022-01-01",
+  "Description[2] of Use Emoji Shorthand for Completion": "如果想自定义完成日期格式或字段名称，或使用 Dataview 内联字段格式，请禁用此功能",
+  "Description[3] of Use Emoji Shorthand for Completion": '只有启用 "自动任务完成跟踪" 之后才可启用此功能',
+
+  "Completion Field Name": "完成字段的名称",
+  "Description[0] of Completion Field Name": "当你在 dataview 视图中完成任务时，在任务末尾添加的完成时间的字段的名称",
+  "Description[1] of Completion Field Name": '只有启用 "自动任务完成跟踪"，并且关闭 “完成时用 Emoji 简写” 之后才可启用此功能',
+
+  "Completion Date Format": "完成字段的日期格式",
+  "Description[0] of Completion Date Format": "当你在 dataview 视图中完成任务时，在任务末尾添加的完成时间的日期格式（参见 Luxon 日期格式）",
+  "Description[1] of Completion Date Format": '只有启用 "自动任务完成跟踪"，并且关闭 “完成时用 Emoji 简写” 之后才可启用此功能',
+  "Description[2] of Completion Date Format": "当前: ",
+
+  "Recursive Sub-Task Completion": "递归完成子任务",
+  "Description of Recursive Sub-Task Completion": "如果启用，当你在 dataview 视图中完成某任务，该任务的所有子任务也会一并完成",
+};

--- a/src/lang/locale/zh-tw.ts
+++ b/src/lang/locale/zh-tw.ts
@@ -1,0 +1,96 @@
+export default {
+  // General Settings
+  'General Settings': '常規設置',
+
+  'Enable Inline Queries': '啓用行內查詢',
+  'Description of Enable Inline Queries': '啓用或禁用執行常規 Dataview 行內查詢',
+
+  'Enable JavaScript Queries': '啓用 JavaScript 查詢',
+  'Description of Enable JavaScript Queries': '啓用或禁用執行 DataviewJS 查詢',
+
+  'Enable Inline JavaScript Queries': '啓用行內 JavaScript 查詢',
+  'Description of Enable Inline JavaScript Queries': '啓用或禁用執行行內 DataviewJS 查詢。需要啓用 DataviewJS 查詢',
+
+  'Enable Inline Field Highlighting in Reading View': '在閱讀視圖中高亮行內字段',
+  'Description of Enable Inline Field Highlighting in Reading View': '在閱讀視圖中，啓用或禁用行內字段的渲染。',
+
+  'Enable Inline Field Highlighting in Live Preview': '在實時預覽中高亮行內字段',
+  'Description of Enable Inline Field Highlighting in Live Preview': '在實時預覽中，啓用或禁用行內字段的渲染。',
+
+  // Codeblock Settings
+  'Codeblock Settings': '代碼塊設置',
+
+  'DataviewJS Keyword': 'DataviewJS 關鍵字',
+  "Description of DataviewJS Keyword": "DataviewJS 代碼塊的關鍵字. 默認是 'dataviewjs'. 需要重啓 Obsidian 才能生效.",
+
+  'Inline Query Prefix': '行內查詢的前綴',
+  "Description of Inline Query Prefix": "行內查詢的前綴 (用來標識 Dataview 查詢)，默認爲 '='。",
+
+  'JavaScript Inline Query Prefix': 'JavaScript 行內查詢的前綴',
+  "Description of JavaScript Inline Query Prefix": "JavaScript 行內查詢的前綴 (用來標識 DataviewJS 查詢)，默認爲 '$='.",
+
+  'Codeblock Inline Queries': '代碼塊行內查詢',
+  'Description of Codeblock Inline Queries': '如果啓用，行內查詢也可以在代碼塊查詢中生效',
+
+  // View Settings
+  'View Settings': '視圖設置',
+
+  // General
+  'General': '常規',
+  'Display result count': '顯示結果數量',
+  'Description of Display result count': '如果關閉，TASK 和 TABLE 查詢結果開頭處的小數字將被隱藏。',
+
+  'Warn on Empty Result': '空結果警告',
+  'Description of Warn on Empty Result': '如果設置，查詢到 0 個結果的查詢將會變爲警告消息',
+
+  'Render Null As': '空值渲染爲',
+  'Description of Render Null As': '默認情況下，表中應該顯示 null 以及不存在的內容。支持 Markdown 語法',
+
+  'Automatic View Refreshing': '自動刷新視圖',
+  'Description of Automatic View Refreshing': '如果啓用，當庫中的文件更改時，視圖將自動刷新。這會產生負面影響',
+
+  'Refresh Interval': '刷新間隔',
+  'Description of Refresh Interval': '文件更改完成後，需要等待多長時間再更新視圖 (單位: 毫秒)',
+
+  'Date Format': '日期格式',
+  'Description of Date Format': "默認的日期和時間的格式 (參見Luxon日期格式)" + " 當前: ",
+  'Onchage Description of Date Format': "默認的日期和時間的格式 (參見Luxon日期格式)" + " 當前: ",
+
+  'Date + Time Format': '日期 + 时间格式',
+  'Description of Date + Time Format': "默認的日期和時間的格式 (參見Luxon日期格式)" + " 當前: ",
+  'Onchage Description of Date + Time Format': "默認的日期和時間的格式 (參見Luxon日期格式)" + " 當前: ",
+
+  // Table Setting
+  "Table Settings": "表格視圖設置",
+
+  "Primary Column Name": "主列名稱",
+  "Description of Primary Column Name": "表格自動生成的第一列的默認 ID 的名稱。內容為鏈接到源文件的鏈接。",
+
+  "Grouped Column Name": "成組的列的名稱",
+  "Description of Grouped Column Name": "指當表格有內容成組後，表格自動生成的第一列的默認 ID 的名稱。內容爲鏈接到源文件的鏈接。",
+
+  // Task Settings
+  "Task Settings": "任務視圖設置",
+
+  "Automatic Task Completion Tracking": "自動任務完成跟蹤",
+  "Description[0] of Automatic Task Completion Tracking": "如果啓用，當在 Dataview 查詢結果中點擊完成任務時，Dataview 將自動給任務附加及其完成日期。",
+  "Description[1] of Automatic Task Completion Tracking": "用默認字段和默認日期格式舉例: - [x] 我的任務 [completion:: 2022-01-01]",
+
+  "Use Emoji Shorthand for Completion": "完成時用 Emoji 簡寫",
+  "Description[0] of Use Emoji Shorthand for Completion": '如果啓用，將使用 emoji 簡寫替代行內任務字段 "completion".',
+  "Description[1] of Use Emoji Shorthand for Completion": "例子: - [x] 我的任務 ✅ 2022-01-01",
+  "Description[2] of Use Emoji Shorthand for Completion": "如果想自定義完成日期格式或字段名稱，或使用 Dataview 內聯字段格式，請禁用此功能",
+  "Description[3] of Use Emoji Shorthand for Completion": '只有啓用 "自動任務完成跟蹤" 之後纔可啓用此功能',
+
+  "Completion Field Name": "完成字段的名稱",
+  "Description[0] of Completion Field Name": "當你在 dataview 視圖中完成任務時，在任務末尾添加的完成時間的字段的名稱",
+  "Description[1] of Completion Field Name": '只有啓用 "自動任務完成跟蹤"，並且關閉 “完成時用 Emoji 簡寫” 之後纔可啓用此功能',
+
+  "Completion Date Format": "完成字段的日期格式",
+  "Description[0] of Completion Date Format": "當你在 dataview 視圖中完成任務時，在任務末尾添加的完成時間的日期格式 (參見 Luxon 日期格式)",
+  "Description[1] of Completion Date Format": '只有啓用 "自動任務完成跟蹤"，並且關閉 “完成時用 Emoji 簡寫” 之後纔可啓用此功能',
+  "Description[2] of Completion Date Format": "當前: ",
+
+  "Recursive Sub-Task Completion": "遞歸完成子任務",
+  "Description of Recursive Sub-Task Completion": "如果啓用，當你在 dataview 視圖中完成某任務，該任務的所有子任務也會一併完成",
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import {
 import { DataviewInit } from "ui/markdown";
 import { inlinePlugin } from "./ui/lp-render";
 import { Extension } from "@codemirror/state";
+import { t } from "./lang/helpers"
 
 export default class DataviewPlugin extends Plugin {
     /** Plugin-wide default settings. */
@@ -298,11 +299,11 @@ class GeneralSettingsTab extends PluginSettingTab {
 
     public display(): void {
         this.containerEl.empty();
-        this.containerEl.createEl("h2", { text: "General Settings" });
+        this.containerEl.createEl("h2", { text: t("General Settings") });
 
         new Setting(this.containerEl)
-            .setName("Enable Inline Queries")
-            .setDesc("Enable or disable executing regular inline Dataview queries.")
+            .setName(t("Enable Inline Queries"))
+            .setDesc(t("Description of Enable Inline Queries"))
             .addToggle(toggle =>
                 toggle
                     .setValue(this.plugin.settings.enableInlineDataview)
@@ -310,8 +311,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Enable JavaScript Queries")
-            .setDesc("Enable or disable executing DataviewJS queries.")
+            .setName(t("Enable JavaScript Queries"))
+            .setDesc(t("Description of Enable JavaScript Queries"))
             .addToggle(toggle =>
                 toggle
                     .setValue(this.plugin.settings.enableDataviewJs)
@@ -319,9 +320,9 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Enable Inline JavaScript Queries")
+            .setName(t("Enable Inline JavaScript Queries"))
             .setDesc(
-                "Enable or disable executing inline DataviewJS queries. Requires that DataviewJS queries are enabled."
+                t("Description of Enable Inline JavaScript Queries")
             )
             .addToggle(toggle =>
                 toggle
@@ -330,8 +331,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Enable Inline Field Highlighting in Reading View")
-            .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields in Reading View.")
+            .setName(t("Enable Inline Field Highlighting in Reading View"))
+            .setDesc("Description of Enable Inline Field Highlighting in Reading View")
             .addToggle(toggle =>
                 toggle
                     .setValue(this.plugin.settings.prettyRenderInlineFields)
@@ -339,8 +340,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Enable Inline Field Highlighting in Live Preview")
-            .setDesc("Enables or disables visual highlighting / pretty rendering for inline fields in Live Preview.")
+            .setName(t("Enable Inline Field Highlighting in Live Preview"))
+            .setDesc(t("Description of Enable Inline Field Highlighting in Live Preview"))
             .addToggle(toggle =>
                 toggle.setValue(this.plugin.settings.prettyRenderInlineFieldsInLivePreview).onChange(async value => {
                     await this.plugin.updateSettings({ prettyRenderInlineFieldsInLivePreview: value });
@@ -348,12 +349,12 @@ class GeneralSettingsTab extends PluginSettingTab {
                 })
             );
 
-        this.containerEl.createEl("h2", { text: "Codeblock Settings" });
+        this.containerEl.createEl("h2", { text: t("Codeblock Settings") });
 
         new Setting(this.containerEl)
-            .setName("DataviewJS Keyword")
+            .setName(t("DataviewJS Keyword"))
             .setDesc(
-                "Keyword for DataviewJS blocks. Defaults to 'dataviewjs'. Reload required for changes to take effect."
+                t("Description of DataviewJS Keyword")
             )
             .addText(text =>
                 text
@@ -366,8 +367,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Inline Query Prefix")
-            .setDesc("The prefix to inline queries (to mark them as Dataview queries). Defaults to '='.")
+            .setName(t("Inline Query Prefix"))
+            .setDesc(t("Description of Inline Query Prefix"))
             .addText(text =>
                 text
                     .setPlaceholder("=")
@@ -380,8 +381,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("JavaScript Inline Query Prefix")
-            .setDesc("The prefix to JavaScript inline queries (to mark them as DataviewJS queries). Defaults to '$='.")
+            .setName(t("JavaScript Inline Query Prefix"))
+            .setDesc(t("Description of JavaScript Inline Query Prefix"))
             .addText(text =>
                 text
                     .setPlaceholder("$=")
@@ -394,20 +395,20 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Codeblock Inline Queries")
-            .setDesc("If enabled, inline queries will also be evaluated inside full codeblocks.")
+            .setName(t("Codeblock Inline Queries"))
+            .setDesc(t("Description of Codeblock Inline Queries"))
             .addToggle(toggle =>
                 toggle
                     .setValue(this.plugin.settings.inlineQueriesInCodeblocks)
                     .onChange(async value => await this.plugin.updateSettings({ inlineQueriesInCodeblocks: value }))
             );
 
-        this.containerEl.createEl("h2", { text: "View Settings" });
-        this.containerEl.createEl("h3", { text: "General" });
+        this.containerEl.createEl("h2", { text: t("View Settings") });
+        this.containerEl.createEl("h3", { text: t("General") });
 
         new Setting(this.containerEl)
-            .setName("Display result count")
-            .setDesc("If toggled off, the small number in the result header of TASK and TABLE Queries will be hidden.")
+            .setName(t("Display result count"))
+            .setDesc(t("Description of Display result count"))
             .addToggle(toggle =>
                 toggle.setValue(this.plugin.settings.showResultCount).onChange(async value => {
                     await this.plugin.updateSettings({ showResultCount: value });
@@ -416,8 +417,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Warn on Empty Result")
-            .setDesc("If set, queries which return 0 results will render a warning message.")
+            .setName(t("Warn on Empty Result"))
+            .setDesc(t("Description of Warn on Empty Result"))
             .addToggle(toggle =>
                 toggle.setValue(this.plugin.settings.warnOnEmptyResult).onChange(async value => {
                     await this.plugin.updateSettings({ warnOnEmptyResult: value });
@@ -426,8 +427,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Render Null As")
-            .setDesc("What null/non-existent should show up as in tables, by default. This supports Markdown notation.")
+            .setName(t("Render Null As"))
+            .setDesc(t("Description of Render Null As"))
             .addText(text =>
                 text
                     .setPlaceholder("-")
@@ -439,11 +440,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Automatic View Refreshing")
-            .setDesc(
-                "If enabled, views will automatically refresh when files in your vault change; this can negatively affect" +
-                    " some functionality like embeds in views, so turn it off if such functionality is not working."
-            )
+            .setName(t("Automatic View Refreshing"))
+            .setDesc(t("Description of Automatic View Refreshing"))
             .addToggle(toggle =>
                 toggle.setValue(this.plugin.settings.refreshEnabled).onChange(async value => {
                     await this.plugin.updateSettings({ refreshEnabled: value });
@@ -452,8 +450,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Refresh Interval")
-            .setDesc("How long to wait (in milliseconds) for files to stop changing before updating views.")
+            .setName(t("Refresh Interval"))
+            .setDesc(t("Description of Refresh Interval"))
             .addText(text =>
                 text
                     .setPlaceholder("500")
@@ -467,10 +465,9 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         let dformat = new Setting(this.containerEl)
-            .setName("Date Format")
+            .setName(t("Date Format"))
             .setDesc(
-                "The default date format (see Luxon date format options)." +
-                    " Currently: " +
+                t("Description of Date Format") +
                     DateTime.now().toFormat(this.plugin.settings.defaultDateFormat, { locale: currentLocale() })
             )
             .addText(text =>
@@ -479,8 +476,7 @@ class GeneralSettingsTab extends PluginSettingTab {
                     .setValue(this.plugin.settings.defaultDateFormat)
                     .onChange(async value => {
                         dformat.setDesc(
-                            "The default date format (see Luxon date format options)." +
-                                " Currently: " +
+                            t("Onchange Description of Date Format") +
                                 DateTime.now().toFormat(value, { locale: currentLocale() })
                         );
                         await this.plugin.updateSettings({ defaultDateFormat: value });
@@ -490,10 +486,9 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         let dtformat = new Setting(this.containerEl)
-            .setName("Date + Time Format")
+            .setName(t("Date + Time Format"))
             .setDesc(
-                "The default date and time format (see Luxon date format options)." +
-                    " Currently: " +
+                t("Description of Date + Time Format") +
                     DateTime.now().toFormat(this.plugin.settings.defaultDateTimeFormat, { locale: currentLocale() })
             )
             .addText(text =>
@@ -502,8 +497,7 @@ class GeneralSettingsTab extends PluginSettingTab {
                     .setValue(this.plugin.settings.defaultDateTimeFormat)
                     .onChange(async value => {
                         dtformat.setDesc(
-                            "The default date and time format (see Luxon date format options)." +
-                                " Currently: " +
+                            t("Onchange Description of Date + Time Format") +
                                 DateTime.now().toFormat(value, { locale: currentLocale() })
                         );
                         await this.plugin.updateSettings({ defaultDateTimeFormat: value });
@@ -512,13 +506,11 @@ class GeneralSettingsTab extends PluginSettingTab {
                     })
             );
 
-        this.containerEl.createEl("h3", { text: "Table Settings" });
+        this.containerEl.createEl("h3", { text: t("Table Settings") });
 
         new Setting(this.containerEl)
-            .setName("Primary Column Name")
-            .setDesc(
-                "The name of the default ID column in tables; this is the auto-generated first column that links to the source file."
-            )
+            .setName(t("Primary Column Name"))
+            .setDesc(t("Description of Primary Column Name"))
             .addText(text =>
                 text
                     .setPlaceholder("File")
@@ -530,11 +522,8 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         new Setting(this.containerEl)
-            .setName("Grouped Column Name")
-            .setDesc(
-                "The name of the default ID column in tables, when the table is on grouped data; this is the auto-generated first column" +
-                    "that links to the source file/group."
-            )
+            .setName(t("Grouped Column Name"))
+            .setDesc(t("Description of Grouped Column Name"))
             .addText(text =>
                 text
                     .setPlaceholder("Group")
@@ -545,23 +534,19 @@ class GeneralSettingsTab extends PluginSettingTab {
                     })
             );
 
-        this.containerEl.createEl("h3", { text: "Task Settings" });
+        this.containerEl.createEl("h3", { text: t("Task Settings") });
 
         let taskCompletionSubsettingsEnabled = this.plugin.settings.taskCompletionTracking;
         let taskCompletionInlineSubsettingsEnabled =
             taskCompletionSubsettingsEnabled && !this.plugin.settings.taskCompletionUseEmojiShorthand;
 
         new Setting(this.containerEl)
-            .setName("Automatic Task Completion Tracking")
+            .setName(t("Automatic Task Completion Tracking"))
             .setDesc(
                 createFragment(el => {
-                    el.appendText(
-                        "If enabled, Dataview will automatically append tasks with their completion date when they are checked in Dataview views."
-                    );
+                    el.appendText(t("Description[0] of Automatic Task Completion Tracking"));
                     el.createEl("br");
-                    el.appendText(
-                        "Example with default field name and date format: - [x] my task [completion:: 2022-01-01]"
-                    );
+                    el.appendText(t("Description[1] of Automatic Task Completion Tracking"));
                 })
             )
             .addToggle(toggle =>
@@ -573,23 +558,19 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
 
         let taskEmojiShorthand = new Setting(this.containerEl)
-            .setName("Use Emoji Shorthand for Completion")
+            .setName(t("Use Emoji Shorthand for Completion"))
             .setDisabled(!taskCompletionSubsettingsEnabled);
         if (taskCompletionSubsettingsEnabled)
             taskEmojiShorthand
                 .setDesc(
                     createFragment(el => {
-                        el.appendText(
-                            'If enabled, will use emoji shorthand instead of inline field formatting to fill out implicit task field "completion".'
-                        );
+                        el.appendText(t("Description[0] of Use Emoji Shorthand for Completion"));
                         el.createEl("br");
-                        el.appendText("Example: - [x] my task ✅ 2022-01-01");
+                        el.appendText(t("Description[1] of Use Emoji Shorthand for Completion"));
                         el.createEl("br");
-                        el.appendText(
-                            "Disable this to customize the completion date format or field name, or to use Dataview inline field formatting."
-                        );
+                        el.appendText(t("Description[2] of Use Emoji Shorthand for Completion"));
                         el.createEl("br");
-                        el.appendText('Only available when "Automatic Task Completion Tracking" is enabled.');
+                        el.appendText(t("Description[3] of Use Emoji Shorthand for Completion"));
                     })
                 )
                 .addToggle(toggle =>
@@ -599,22 +580,18 @@ class GeneralSettingsTab extends PluginSettingTab {
                         this.display();
                     })
                 );
-        else taskEmojiShorthand.setDesc('Only available when "Automatic Task Completion Tracking" is enabled.');
+        else taskEmojiShorthand.setDesc(t("Description[3] of Use Emoji Shorthand for Completion"));
 
         let taskFieldName = new Setting(this.containerEl)
-            .setName("Completion Field Name")
+            .setName(t("Completion Field Name"))
             .setDisabled(!taskCompletionInlineSubsettingsEnabled);
         if (taskCompletionInlineSubsettingsEnabled)
             taskFieldName
                 .setDesc(
                     createFragment(el => {
-                        el.appendText(
-                            "Text used as inline field key for task completion date when toggling a task's checkbox in a dataview view."
-                        );
+                        el.appendText(t("Description[0] of Completion Field Name"));
                         el.createEl("br");
-                        el.appendText(
-                            'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.'
-                        );
+                        el.appendText(t("Description[1] of Completion Field Name"));
                     })
                 )
                 .addText(text =>
@@ -623,18 +600,16 @@ class GeneralSettingsTab extends PluginSettingTab {
                     })
                 );
         else
-            taskFieldName.setDesc(
-                'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.'
-            );
+            taskFieldName.setDesc(t("Description[1] of Completion Field Name"));
 
         let taskDtFormat = new Setting(this.containerEl)
-            .setName("Completion Date Format")
+            .setName(t("Completion Date Format"))
             .setDisabled(!taskCompletionInlineSubsettingsEnabled);
         if (taskCompletionInlineSubsettingsEnabled) {
             let descTextLines = [
-                "Date-time format for task completion date when toggling a task's checkbox in a dataview view (see Luxon date format options).",
-                'Only available when "Automatic Task Completion Tracking" is enabled and "Use Emoji Shorthand for Completion" is disabled.',
-                "Currently: ",
+                t("Description[0] of Completion Date Format"),
+                t("Description[1] of Completion Date Format"),
+                t("Description[2] of Completion Date Format"),
             ];
             taskDtFormat
                 .setDesc(
@@ -678,9 +653,9 @@ class GeneralSettingsTab extends PluginSettingTab {
             );
         }
         new Setting(this.containerEl)
-            .setName("Recursive Sub-Task Completion")
+            .setName(t("Recursive Sub-Task Completion"))
             // I gotta word this better :/
-            .setDesc("If enabled, completing a task in a DataView will automatically complete its subtasks too.")
+            .setDesc(t("Description of Recursive Sub-Task Completion"))
             .addToggle(toggle =>
                 toggle
                     .setValue(this.plugin.settings.recursiveSubTaskCompletion)


### PR DESCRIPTION
Two language translations have been added to the setup of the dataview: simplified Chinese and Traditional Chinese, hoping to help people better understand and use dataview.

New
- src
  - lang
    - locale: Various languages translation
    - helpers.ts

The 'src/lang/locale' folder reserves files for adding translations for other languages.