### PR TITLE
Fix: markdown render api change due to deprecation

### DIFF
--- a/src/api/inline-api.ts
+++ b/src/api/inline-api.ts
@@ -288,7 +288,7 @@ export class DataviewInlineApi {
         }
 
         let _el = container.createEl(el, options);
-        renderValue(wrapped.value, _el, this.currentFilePath, this.component, this.settings, true);
+        renderValue(this.app, wrapped.value, _el, this.currentFilePath, this.component, this.settings, true);
         return _el;
     }
 
@@ -343,6 +343,7 @@ export class DataviewInlineApi {
             let result = await Promise.resolve(func(this, input));
             if (result)
                 await renderValue(
+                    this.app,
                     result as any,
                     this.container,
                     this.currentFilePath,

--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -543,7 +543,7 @@ export class DataviewApi {
         filePath: string,
         inline: boolean = false
     ) {
-        return renderValue(value as Literal, container, filePath, component, this.settings, inline);
+        return renderValue(this.app, value as Literal, container, filePath, component, this.settings, inline);
     }
 
     /////////////////

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -317,7 +317,7 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                             } else {
                                 const { value } = intermediateResult;
                                 result = value;
-                                renderValue(result, el, currentFile.path, this.component, settings);
+                                renderValue(app, result, el, currentFile.path, this.component, settings);
                             }
                         }
                     } else {
@@ -334,12 +334,12 @@ export function inlinePlugin(app: App, index: FullIndex, settings: DataviewSetti
                             if (code.includes("await")) {
                                 (evalInContext("(async () => { " + PREAMBLE + code + " })()") as Promise<any>).then(
                                     (result: any) => {
-                                        renderValue(result, el, currentFile.path, this.component, settings);
+                                        renderValue(app, result, el, currentFile.path, this.component, settings);
                                     }
                                 );
                             } else {
                                 result = evalInContext(PREAMBLE + code);
-                                renderValue(result, el, currentFile.path, this.component, settings);
+                                renderValue(app, result, el, currentFile.path, this.component, settings);
                             }
 
                             function evalInContext(script: string): any {

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -1,4 +1,4 @@
-import { Component, MarkdownRenderer } from "obsidian";
+import { App, Component, MarkdownRenderer } from "obsidian";
 import { DataArray } from "api/data-array";
 import { QuerySettings } from "settings";
 import { currentLocale } from "util/locale";
@@ -7,6 +7,7 @@ import { Literal, Values, Widgets } from "data-model/value";
 
 /** Render simple fields compactly, removing wrapping content like paragraph and span. */
 export async function renderCompactMarkdown(
+    app: App,
     markdown: string,
     container: HTMLElement,
     sourcePath: string,
@@ -15,7 +16,7 @@ export async function renderCompactMarkdown(
 ) {
     // check if the call is from the CM6 view plugin defined in src/ui/views/inline-field-live-preview.ts
     if (isInlineFieldLivePreview) {
-        await renderCompactMarkdownForInlineFieldLivePreview(markdown, container, sourcePath, component);
+        await renderCompactMarkdownForInlineFieldLivePreview(app, markdown, container, sourcePath, component);
     } else {
         let subcontainer = container.createSpan();
         await MarkdownRenderer.render(app, markdown, subcontainer, sourcePath, component);
@@ -31,6 +32,7 @@ export async function renderCompactMarkdown(
 }
 
 async function renderCompactMarkdownForInlineFieldLivePreview(
+    app: App,
     markdown: string,
     container: HTMLElement,
     sourcePath: string,
@@ -68,6 +70,7 @@ export type ValueRenderContext = "root" | "list";
 
 /** Prettily render a value into a container with the given settings. */
 export async function renderValue(
+    app: App,
     field: Literal,
     container: HTMLElement,
     originFile: string,
@@ -85,20 +88,21 @@ export async function renderValue(
     }
 
     if (Values.isNull(field)) {
-        await renderCompactMarkdown(settings.renderNullAs, container, originFile, component, isInlineFieldLivePreview);
+        await renderCompactMarkdown(app, settings.renderNullAs, container, originFile, component, isInlineFieldLivePreview);
     } else if (Values.isDate(field)) {
         container.appendText(renderMinimalDate(field, settings, currentLocale()));
     } else if (Values.isDuration(field)) {
         container.appendText(renderMinimalDuration(field));
     } else if (Values.isString(field) || Values.isBoolean(field) || Values.isNumber(field)) {
-        await renderCompactMarkdown("" + field, container, originFile, component, isInlineFieldLivePreview);
+        await renderCompactMarkdown(app, "" + field, container, originFile, component, isInlineFieldLivePreview);
     } else if (Values.isLink(field)) {
-        await renderCompactMarkdown(field.markdown(), container, originFile, component, isInlineFieldLivePreview);
+        await renderCompactMarkdown(app, field.markdown(), container, originFile, component, isInlineFieldLivePreview);
     } else if (Values.isHtml(field)) {
         container.appendChild(field);
     } else if (Values.isWidget(field)) {
         if (Widgets.isListPair(field)) {
             await renderValue(
+                app,
                 field.key,
                 container,
                 originFile,
@@ -111,6 +115,7 @@ export async function renderValue(
             );
             container.appendText(": ");
             await renderValue(
+                app,
                 field.value,
                 container,
                 originFile,
@@ -146,6 +151,7 @@ export async function renderValue(
             for (let child of field) {
                 let li = list.createEl("li", { cls: "dataview-result-list-li" });
                 await renderValue(
+                    app,
                     child,
                     li,
                     originFile,
@@ -170,6 +176,7 @@ export async function renderValue(
                 else span.appendText(", ");
 
                 await renderValue(
+                    app,
                     val,
                     span,
                     originFile,
@@ -195,6 +202,7 @@ export async function renderValue(
                 let li = list.createEl("li", { cls: ["dataview", "dataview-li", "dataview-result-object-li"] });
                 li.appendText(key + ": ");
                 await renderValue(
+                    app,
                     value,
                     li,
                     originFile,
@@ -220,6 +228,7 @@ export async function renderValue(
 
                 span.appendText(key + ": ");
                 await renderValue(
+                    app,
                     value,
                     span,
                     originFile,

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -18,7 +18,7 @@ export async function renderCompactMarkdown(
         await renderCompactMarkdownForInlineFieldLivePreview(markdown, container, sourcePath, component);
     } else {
         let subcontainer = container.createSpan();
-        await MarkdownRenderer.renderMarkdown(markdown, subcontainer, sourcePath, component);
+        await MarkdownRenderer.render(app, markdown, subcontainer, sourcePath, component);
 
         let paragraph = subcontainer.querySelector(":scope > p");
         if (subcontainer.children.length == 1 && paragraph) {
@@ -37,7 +37,7 @@ async function renderCompactMarkdownForInlineFieldLivePreview(
     component: Component
 ) {
     const tmpContainer = createSpan();
-    await MarkdownRenderer.renderMarkdown(markdown, tmpContainer, sourcePath, component);
+    await MarkdownRenderer.render(app, markdown, tmpContainer, sourcePath, component);
 
     let paragraph = tmpContainer.querySelector(":scope > p");
     if (tmpContainer.childNodes.length == 1 && paragraph) {

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -235,12 +235,13 @@ class InlineFieldWidget extends WidgetType {
                 },
             });
 
-            renderCompactMarkdown(this.field.key, key, this.sourcePath, this.component, true);
+            renderCompactMarkdown(this.app, this.field.key, key, this.sourcePath, this.component, true);
 
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-value"],
             });
             renderValue(
+                this.app,
                 parseInlineValue(this.field.value),
                 value,
                 this.sourcePath,
@@ -259,6 +260,7 @@ class InlineFieldWidget extends WidgetType {
                 cls: ["dataview", "inline-field-standalone-value"],
             });
             renderValue(
+                this.app,
                 parseInlineValue(this.field.value),
                 value,
                 this.sourcePath,

--- a/src/ui/views/inline-view.ts
+++ b/src/ui/views/inline-view.ts
@@ -34,7 +34,7 @@ export class DataviewInlineRenderer extends DataviewRefreshableRenderer {
         } else {
             let temp = document.createElement("span");
             temp.addClasses(["dataview", "dataview-inline-query"]);
-            await renderValue(result.value, temp, this.origin, this, this.settings, false);
+            await renderValue(this.app, result.value, temp, this.origin, this, this.settings, false);
 
             this.target.replaceWith(temp);
         }

--- a/src/ui/views/js-view.ts
+++ b/src/ui/views/js-view.ts
@@ -72,7 +72,7 @@ export class DataviewInlineJSRenderer extends DataviewRefreshableRenderer {
             this.target = temp;
             if (result === undefined) return;
 
-            renderValue(result, temp, this.origin, this, this.settings, false);
+            renderValue(this.api.app, result, temp, this.origin, this, this.settings, false);
         } catch (e) {
             this.errorbox = this.container.createEl("div");
             renderErrorPre(this.errorbox, "Dataview (for inline JS query '" + this.script + "'): " + e);


### PR DESCRIPTION
closes #177
closes #781

![image](https://github.com/blacksmithgu/obsidian-dataview/assets/559564/f21c934c-5b9f-4331-97e1-73fd9c33e128)
https://docs.obsidian.md/Reference/TypeScript+API/MarkdownRenderer/renderMarkdown
https://docs.obsidian.md/Reference/TypeScript+API/MarkdownRenderer/render