### PR TITLE
fixing tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "src",
     "sourceMap": true,
-    "inlineSourceMap": true,
+    "inlineSourceMap": false,
     "inlineSources": true,
     "module": "ESNext",
     "target": "ES2022",


### PR DESCRIPTION
as #2271 is fixing the linting error from #2266, this will fix another issue with tsconfig.json.

`sourceMap` and `inlineSourceMap` can't be combined technically.
![image](https://github.com/blacksmithgu/obsidian-dataview/assets/559564/8ca75492-bf80-4e19-8fda-4b4dbfa12ba9)
