### PR TITLE
Add overflow-x auto to codeblocks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -218,6 +218,7 @@ export default class DataviewPlugin extends Plugin {
         component: Component | MarkdownPostProcessorContext,
         sourcePath: string
     ) {
+        el.style.overflowX = "auto";
         this.api.execute(source, el, component, sourcePath);
     }
 
@@ -228,6 +229,7 @@ export default class DataviewPlugin extends Plugin {
         component: Component | MarkdownPostProcessorContext,
         sourcePath: string
     ) {
+        el.style.overflowX = "auto";
         this.api.executeJs(source, el, component, sourcePath);
     }
 


### PR DESCRIPTION
closes #2220
closes #2022
closes #844

Hello there.
this is the a step towards syntax highlighting in dataview blocks.
as it currently is implemented, it fixes the above linked issue.

this gem will adapt styles based on plugin settings in real time with high efficiency:
![image](https://github.com/blacksmithgu/obsidian-dataview/assets/559564/71f50576-bfa2-4355-b6a7-317234d9fa76)
![image](https://github.com/blacksmithgu/obsidian-dataview/assets/559564/f834b979-342f-4cbe-80fa-4d26f6d26964)