### PR TITLE
bug 2253 - Allow for the date to be null

### DIFF
--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -292,6 +292,7 @@ export namespace DefaultFunctions {
                 }
             }
         })
+        .add2("null", "string", () => null)
         .add1("null", () => null)
         .vectorize(1, [0])
         .build();

--- a/src/test/function/functions.test.ts
+++ b/src/test/function/functions.test.ts
@@ -157,4 +157,5 @@ test("Evaluate date()", () => {
     expect(parseEval('date("210313", "yyMMdd")')).toEqual(DateTime.fromObject({ year: 2021, month: 3, day: 13 }));
     expect(parseEval('date("946778645012","x")')).toEqual(DateTime.fromMillis(946778645012));
     expect(parseEval('date("946778645","X")')).toEqual(DateTime.fromMillis(946778645000));
+    expect(DefaultFunctions.date(simpleContext(), null, "MM/dd/yyyy")).toEqual(null);
 });

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -88,7 +88,14 @@ export async function renderValue(
     }
 
     if (Values.isNull(field)) {
-        await renderCompactMarkdown(app, settings.renderNullAs, container, originFile, component, isInlineFieldLivePreview);
+        await renderCompactMarkdown(
+            app,
+            settings.renderNullAs,
+            container,
+            originFile,
+            component,
+            isInlineFieldLivePreview
+        );
     } else if (Values.isDate(field)) {
         container.appendText(renderMinimalDate(field, settings, currentLocale()));
     } else if (Values.isDuration(field)) {


### PR DESCRIPTION
Fixed #2253 allowing the date to null, returning null, instead of breaking the query.

(Also ran `npm run format` which picked up some correction of formatting in render.ts)