### PR TITLE
critical api fix: verNum should not be undefined

### DIFF
--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -105,13 +105,13 @@ export class DataviewApi {
         compare: (op: CompareOperator, ver: string) => boolean;
         satisfies: (range: string) => boolean;
     } = (() => {
-        const { verNum: version } = this;
+        const self = this;
         return {
             get current() {
-                return version;
+                return self.verNum;
             },
-            compare: (op: CompareOperator, ver: string) => compare(version, ver, op),
-            satisfies: (range: string) => satisfies(version, range),
+            compare: (op: CompareOperator, ver: string) => compare(this.verNum, ver, op),
+            satisfies: (range: string) => satisfies(this.verNum, range),
         };
     })();
 


### PR DESCRIPTION
closes #2276

this breaks excalibrain and other plugins that use the api to compare versions.

for some strange reason, closures like that now run pre-constructor so verNum is not defined at that point in time.
must be related to a change in electron / v8 or how the plugin builds.