### PR TITLE
Fixes "regexmatch" Example in Function Calls Documentation

### DIFF
--- a/docs/docs/reference/expressions.md
+++ b/docs/docs/reference/expressions.md
@@ -175,7 +175,7 @@ TABLE id, episode_metadata.next, aliases[0]
 
 Dataview supports various functions for manipulating data, which are described in full in the [functions
 documentation](../functions). They have the general syntax `function(arg1, arg2, ...)` - i.e., `lower(file.name)` or
-`regexmatch(file.folder, "A.+")`.
+`regexmatch("A.+", file.folder)`.
 
 ~~~
 ```dataview


### PR DESCRIPTION
This PR fixes a wrong example of usage of the "regexmatch" function in the function call documentation. According to [this docs page](https://blacksmithgu.github.io/obsidian-dataview/reference/expressions/) the usage should be `regexmatch(regex, str)`.