### PR TITLE
Update Breadcrumbs link in friends.md

### DIFF
--- a/docs/docs/friends.md
+++ b/docs/docs/friends.md
@@ -7,7 +7,7 @@ A list of plugins which may be helpful for Dataview related workflows:
 Another non-exhaustive list of plugins which use Dataview for some of the heavy-lifting required for their features:
 
  - [Kanban](https://github.com/mgmeyers/obsidian-kanban) - Create markdown-backed Kanban boards in Obsidian
- - [Breadcrumbs](https://breadcrumbs-wiki.onrender.com/docs/Home) - Gives you a way to visualise a custom-built hierarchy in your Obsidian vault
+ - [Breadcrumbs](http://publish.obsidian.md/breadcrumbs-docs) - Gives you a way to visualise a custom-built hierarchy in your Obsidian vault
  - [Supercharged Links](https://github.com/mdelobelle/obsidian_supercharged_links) - Allows you to style links in your Obsidian vault based on note metadata
 
 A full list can be found using GitHub's [Dependents](https://github.com/blacksmithgu/obsidian-dataview/network/dependents) feature.


### PR DESCRIPTION
Breadcrumbs now uses an Obsidian Publish site to host its docs :)