### PR TITLE
feat: Support custom metadata extractors for tasks

### DIFF
--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -35,6 +35,7 @@ import { Query } from "query/query";
 import { DataviewCalendarRenderer } from "ui/views/calendar-view";
 import { DataviewJSRenderer } from "ui/views/js-view";
 import { markdownList, markdownTable, markdownTaskList } from "ui/export/markdown";
+import { ExtensionRegistry } from "util/extensionRegistry";
 
 /** Asynchronous API calls related to file / system IO. */
 export class DataviewIOApi {
@@ -87,6 +88,8 @@ export class DataviewApi {
     public widget = Widgets;
     /** Re-exporting of luxon for people who can't easily require it. Sorry! */
     public luxon = Luxon;
+    /** Programmatic extensions to tweak dataview behavior */
+    public extensionRegistry: ExtensionRegistry;
 
     public constructor(
         public app: App,

--- a/src/api/plugin-api.ts
+++ b/src/api/plugin-api.ts
@@ -35,7 +35,7 @@ import { Query } from "query/query";
 import { DataviewCalendarRenderer } from "ui/views/calendar-view";
 import { DataviewJSRenderer } from "ui/views/js-view";
 import { markdownList, markdownTable, markdownTaskList } from "ui/export/markdown";
-import { ExtensionRegistry } from "util/extensionRegistry";
+import { extensionRegistry } from "util/extensionRegistry";
 
 /** Asynchronous API calls related to file / system IO. */
 export class DataviewIOApi {
@@ -89,7 +89,7 @@ export class DataviewApi {
     /** Re-exporting of luxon for people who can't easily require it. Sorry! */
     public luxon = Luxon;
     /** Programmatic extensions to tweak dataview behavior */
-    public extensionRegistry: ExtensionRegistry;
+    public extensionRegistry = extensionRegistry;
 
     public constructor(
         public app: App,

--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -4,6 +4,7 @@ import { EXPRESSION } from "expression/parse";
 import { Literal } from "data-model/value";
 import * as P from "parsimmon";
 import emojiRegex from "emoji-regex";
+import { extensionRegistry } from "util/extensionRegistry";
 
 /** A parsed inline field. */
 export interface InlineField {
@@ -209,6 +210,14 @@ function extractSpecialTaskFields(line: string): InlineField[] {
             end: match.index + match[0].length,
             wrapping: "emoji-shorthand",
         });
+    }
+
+    for (const customExtractor of extensionRegistry._customSpecialTaskFieldExtractors) {
+        try {
+            results.push(customExtractor.exec(line));
+        } catch (ex) {
+            console.error(`Custom extractor ${customExtractor.name} failed to extract metadata`, ex, line);
+        }
     }
 
     return results;

--- a/src/util/extensionRegistry.ts
+++ b/src/util/extensionRegistry.ts
@@ -1,0 +1,15 @@
+import type { InlineField } from "data-import/inline-field";
+
+export interface CustomSpecialTaskFieldExtractor {
+    name: string;
+    exec: (line: string) => InlineField;
+}
+export class ExtensionRegistry {
+    _customSpecialTaskFieldExtractors: Array<CustomSpecialTaskFieldExtractor> = [];
+
+    addCustomSpecialTaskFieldExtractor(customExtractor: CustomSpecialTaskFieldExtractor) {
+        this._customSpecialTaskFieldExtractors.push(customExtractor);
+    }
+}
+
+export const extensionRegistry = new ExtensionRegistry();

--- a/src/util/extensionRegistry.ts
+++ b/src/util/extensionRegistry.ts
@@ -1,10 +1,10 @@
 import type { InlineField } from "data-import/inline-field";
 
-interface CustomSpecialTaskFieldExtractor {
+export interface CustomSpecialTaskFieldExtractor {
     name: string;
     exec: (line: string) => InlineField;
 }
-class ExtensionRegistry {
+export class ExtensionRegistry {
     _customSpecialTaskFieldExtractors: Array<CustomSpecialTaskFieldExtractor> = [];
 
     addCustomSpecialTaskFieldExtractor(customExtractor: CustomSpecialTaskFieldExtractor) {

--- a/src/util/extensionRegistry.ts
+++ b/src/util/extensionRegistry.ts
@@ -1,10 +1,10 @@
 import type { InlineField } from "data-import/inline-field";
 
-export interface CustomSpecialTaskFieldExtractor {
+interface CustomSpecialTaskFieldExtractor {
     name: string;
     exec: (line: string) => InlineField;
 }
-export class ExtensionRegistry {
+class ExtensionRegistry {
     _customSpecialTaskFieldExtractors: Array<CustomSpecialTaskFieldExtractor> = [];
 
     addCustomSpecialTaskFieldExtractor(customExtractor: CustomSpecialTaskFieldExtractor) {


### PR DESCRIPTION
Draft implementation to support custom metadata extractors for tasks. Should unblock extracting more emoji-based metadata by third-party plugins relying on dataview.

Closes #2391