### PR TITLE
feat: Trigger an event when a task is clicked

### DIFF
--- a/src/data-index/index.ts
+++ b/src/data-index/index.ts
@@ -81,7 +81,7 @@ export class FullIndex extends Component {
     }
 
     /** Trigger a metadata event on the metadata cache. */
-    private trigger(...args: any[]): void {
+    public trigger(...args: any[]): void {
         this.metadataCache.trigger("dataview:metadata-change", ...args);
     }
 

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -89,6 +89,7 @@ function TaskItem({ item }: { item: STask }) {
                     );
                 }
                 await rewriteTask(context.app.vault, _item, status, updatedText);
+                context.index.trigger("task-click", _item, status, updatedText)
             }
             context.app.workspace.trigger("dataview:refresh-views");
         }


### PR DESCRIPTION
Obsidian Tasks supports recurring tasks, but they do not work if tasks are queried by Dataview - Obsidian Tasks does not watch the filesystem, so it cannot possibly know that a task has been re-written by Dataview, therefore it can't create a new recurrence (see https://publish.obsidian.md/tasks/Other+Plugins/Dataview)
If Dataview trigerred an event, then Obsidian Tasks and any other task-related plugin could subscribe to it and execute any custom logic.