### PR TITLE
Calendar preview shows correct files for each dot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-dataview",
-  "version": "0.5.66",
+  "version": "0.5.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-dataview",
-      "version": "0.5.66",
+      "version": "0.5.67",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "https://github.com/lishid/cm-language",

--- a/src/ui/views/calendar-view.ts
+++ b/src/ui/views/calendar-view.ts
@@ -80,7 +80,26 @@ export class DataviewCalendarRenderer extends DataviewRefreshableRenderer {
                         return;
                     }
 
-                    renderer.app.workspace.trigger("link-hover", {}, targetEl, vals[0].link.path, vals[0].link.path);
+                    let dayEl: Element = targetEl as Element;
+                    while (!dayEl.classList.contains("day")) dayEl = dayEl.parentElement!;
+
+                    for (const [i, dot] of [...dayEl.children[0].children].entries()) {
+                        dot.setAttribute("data-dot-idx", i + "");
+                    }
+
+                    let dotEl: Element = targetEl as Element;
+                    if (dotEl.tagName.toLowerCase() === "div") return; // No dot hovered.
+                    if (dotEl.tagName.toLowerCase() === "circle") dotEl = dotEl.parentElement!;
+
+                    const dotIdx = parseInt(dotEl.getAttribute("data-dot-idx")!);
+
+                    renderer.app.workspace.trigger(
+                        "link-hover",
+                        {},
+                        targetEl,
+                        vals[dotIdx].link.path,
+                        vals[dotIdx].link.path
+                    );
                 },
                 onClickDay: async date => {
                     const vals = dateMap.get(date.format("YYYYMMDD"));


### PR DESCRIPTION
Fixes #1798 with a stable dot hover detection system.

The issue was that, if you hovered a day on the calendar preview, you would only be able to see the first file from that day. This allows you to hover over a specific dot to see a specific file from that day. I wrote an initial implementation, then looked and saw https://github.com/lizhuoran1019/obsidian-dataview/commit/3afb3c71a188f73047c47f5c6717087b8a1a6cd8, which seemed to be a bit similar to mine, and theirs had some flaw in it which mine also did. The people there suggested using `data-` tags, which I tried, and it now seems to work quite reliably.

There is still an issue where, if you move your mouse around on the dots, multiple previews stack up back to back. I have an idea on how to fix this, but I don't know the Obsidian events API enough to be able to close a hover preview. If someone knows that, I would appreciate it, but this should resolve #1798 for now.