### PR TITLE
Instantiate Per Codeblock Refresh Disabling

### DIFF
--- a/docs/docs/api/intro.md
+++ b/docs/docs/api/intro.md
@@ -20,11 +20,11 @@ reference](../code-reference/).
 
 ## Disabling Automatic View Refresh Individually
 
-This is especially useful when using Dataview to render diagrams that are static and do not change, yet allows for `Automatic view refreshing` to work as intended across the rest of your vault. Simply add `disable-refresh` anywhere as a comment within your codeblock to disable refreshing for that particular script.
+This is especially useful when using Dataview to render diagrams that are static and do not change, yet allows for `Automatic view refreshing` to work as intended across the rest of your vault. Simply add `@dataviewjs-disable-refresh` anywhere as a comment within your codeblock to disable refreshing for that particular script.
 
 ~~~
 ```dataviewjs
-// disable-refresh
+// @dataviewjs-disable-refresh
 await dv.view("diagram", 0)
 ```
 ~~~

--- a/docs/docs/api/intro.md
+++ b/docs/docs/api/intro.md
@@ -18,6 +18,17 @@ Code executed in such codeblocks have access to the `dv` variable, which provide
 dataview API (like `dv.table()`, `dv.pages()`, and so on). For more information, check out the [codeblock API
 reference](../code-reference/).
 
+## Disabling Automatic View Refresh Individually
+
+This is especially useful when using Dataview to render diagrams that are static and do not change, yet allows for `Automatic view refreshing` to work as intended across the rest of your vault. Simply add `disable-refresh` anywhere as a comment within your codeblock to disable refreshing for that particular script.
+
+~~~
+```dataviewjs
+// disable-refresh
+await dv.view("diagram", 0)
+```
+~~~
+
 ## Plugin Access
 
 You can access the Dataview Plugin API (from other plugins or the console) through `app.plugins.plugins.dataview.api`;

--- a/src/ui/refreshable-view.ts
+++ b/src/ui/refreshable-view.ts
@@ -10,7 +10,8 @@ export abstract class DataviewRefreshableRenderer extends MarkdownRenderChild {
         public container: HTMLElement,
         public index: FullIndex,
         public app: App,
-        public settings: DataviewSettings
+        public settings: DataviewSettings,
+        public disableRefreshComment?: boolean
     ) {
         super(container);
         this.lastReload = 0;
@@ -20,11 +21,13 @@ export abstract class DataviewRefreshableRenderer extends MarkdownRenderChild {
 
     onload() {
         this.render();
-        this.lastReload = this.index.revision;
-        // Refresh after index changes stop.
-        this.registerEvent(this.app.workspace.on("dataview:refresh-views", this.maybeRefresh));
-        // ...or when the DOM is shown (sidebar expands, tab selected, nodes scrolled into view).
-        this.register(this.container.onNodeInserted(this.maybeRefresh));
+        if(!this.disableRefreshComment) {
+            this.lastReload = this.index.revision;
+            // Refresh after index changes stop.
+            this.registerEvent(this.app.workspace.on("dataview:refresh-views", this.maybeRefresh));
+            // ...or when the DOM is shown (sidebar expands, tab selected, nodes scrolled into view).
+            this.register(this.container.onNodeInserted(this.maybeRefresh));
+        }
     }
 
     maybeRefresh = () => {

--- a/src/ui/views/js-view.ts
+++ b/src/ui/views/js-view.ts
@@ -7,7 +7,7 @@ export class DataviewJSRenderer extends DataviewRefreshableRenderer {
     static PREAMBLE: string = "const dataview = this;const dv = this;";
 
     constructor(public api: DataviewApi, public script: string, public container: HTMLElement, public origin: string) {
-        super(container, api.index, api.app, api.settings);
+        super(container, api.index, api.app, api.settings, script.contains('disable-refresh'));
     }
 
     async render() {

--- a/src/ui/views/js-view.ts
+++ b/src/ui/views/js-view.ts
@@ -7,7 +7,7 @@ export class DataviewJSRenderer extends DataviewRefreshableRenderer {
     static PREAMBLE: string = "const dataview = this;const dv = this;";
 
     constructor(public api: DataviewApi, public script: string, public container: HTMLElement, public origin: string) {
-        super(container, api.index, api.app, api.settings, script.contains('disable-refresh'));
+        super(container, api.index, api.app, api.settings, script.contains('@dataviewjs-disable-refresh'));
     }
 
     async render() {


### PR DESCRIPTION
Simple solution and only applicable to `dataviewjs`.

Allows for a comment within the codeblock—`disable-refresh`—to disable automatic refreshing for select `dataviewjs` queries. Thus, preventing flashing of rendered diagrams yet still allowing the functionality of automatic view refreshing. 

Example:
~~~
```dataviewjs
// @dataviewjs-disable-refresh
await dv.view("diagram", 0)
```
~~~

![Jul-29-2024 22-23-47](https://github.com/user-attachments/assets/43ad0d97-c7fb-4d46-8419-b1aa2dd1f4ca)

Fixes: https://github.com/blacksmithgu/obsidian-dataview/issues/2396