### PR TITLE
Update "Fix inline list rendering in live preview  (#2387)"

### DIFF
--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -40,11 +40,11 @@ async function renderCompactMarkdownForInlineFieldLivePreview(
 ) {
     const tmpContainer = createSpan();
     await MarkdownRenderer.render(app, markdown, tmpContainer, sourcePath, component);
-
     let paragraph = tmpContainer.querySelector(":scope > p");
     if (tmpContainer.childNodes.length == 1 && paragraph) {
-        container.replaceChildren(...paragraph.childNodes);
+        container.appendChild(paragraph.childNodes.item(paragraph.childNodes.length-1));
     } else {
+        console.log("B");
         container.replaceChildren(...tmpContainer.childNodes);
     }
 

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -42,9 +42,8 @@ async function renderCompactMarkdownForInlineFieldLivePreview(
     await MarkdownRenderer.render(app, markdown, tmpContainer, sourcePath, component);
     let paragraph = tmpContainer.querySelector(":scope > p");
     if (tmpContainer.childNodes.length == 1 && paragraph) {
-        container.appendChild(paragraph.childNodes.item(paragraph.childNodes.length-1));
+        container.appendChild(paragraph.childNodes.item(paragraph.childNodes.length - 1));
     } else {
-        console.log("B");
         container.replaceChildren(...tmpContainer.childNodes);
     }
 

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -11,18 +11,44 @@ export async function renderCompactMarkdown(
     markdown: string,
     container: HTMLElement,
     sourcePath: string,
+    component: Component,
+    isInlineFieldLivePreview: boolean = false
+) {
+    // check if the call is from the CM6 view plugin defined in src/ui/views/inline-field-live-preview.ts
+    if (isInlineFieldLivePreview) {
+        await renderCompactMarkdownForInlineFieldLivePreview(app, markdown, container, sourcePath, component);
+    } else {
+        let subcontainer = container.createSpan();
+        await MarkdownRenderer.render(app, markdown, subcontainer, sourcePath, component);
+
+        let paragraph = subcontainer.querySelector(":scope > p");
+        if (subcontainer.children.length == 1 && paragraph) {
+            while (paragraph.firstChild) {
+                subcontainer.appendChild(paragraph.firstChild);
+            }
+            subcontainer.removeChild(paragraph);
+        }
+    }
+}
+
+async function renderCompactMarkdownForInlineFieldLivePreview(
+    app: App,
+    markdown: string,
+    container: HTMLElement,
+    sourcePath: string,
     component: Component
 ) {
-    let subcontainer = container.createSpan();
-    await MarkdownRenderer.render(app, markdown, subcontainer, sourcePath, component);
+    const tmpContainer = createSpan();
+    await MarkdownRenderer.render(app, markdown, tmpContainer, sourcePath, component);
 
-    let paragraph = subcontainer.querySelector(":scope > p");
-    if (subcontainer.children.length == 1 && paragraph) {
-        while (paragraph.firstChild) {
-            subcontainer.appendChild(paragraph.firstChild);
-        }
-        subcontainer.removeChild(paragraph);
+    let paragraph = tmpContainer.querySelector(":scope > p");
+    if (tmpContainer.childNodes.length == 1 && paragraph) {
+        container.replaceChildren(...paragraph.childNodes);
+    } else {
+        container.replaceChildren(...tmpContainer.childNodes);
     }
+
+    tmpContainer.remove();
 }
 
 /** Render a pre block with an error in it; returns the element to allow for dynamic updating. */
@@ -62,15 +88,22 @@ export async function renderValue(
     }
 
     if (Values.isNull(field)) {
-        await renderCompactMarkdown(app, settings.renderNullAs, container, originFile, component);
+        await renderCompactMarkdown(
+            app,
+            settings.renderNullAs,
+            container,
+            originFile,
+            component,
+            isInlineFieldLivePreview
+        );
     } else if (Values.isDate(field)) {
         container.appendText(renderMinimalDate(field, settings, currentLocale()));
     } else if (Values.isDuration(field)) {
         container.appendText(renderMinimalDuration(field));
     } else if (Values.isString(field) || Values.isBoolean(field) || Values.isNumber(field)) {
-        await renderCompactMarkdown(app, "" + field, container, originFile, component);
+        await renderCompactMarkdown(app, "" + field, container, originFile, component, isInlineFieldLivePreview);
     } else if (Values.isLink(field)) {
-        await renderCompactMarkdown(app, field.markdown(), container, originFile, component);
+        await renderCompactMarkdown(app, field.markdown(), container, originFile, component, isInlineFieldLivePreview);
     } else if (Values.isHtml(field)) {
         container.appendChild(field);
     } else if (Values.isWidget(field)) {

--- a/src/ui/views/inline-field-live-preview.ts
+++ b/src/ui/views/inline-field-live-preview.ts
@@ -235,12 +235,11 @@ class InlineFieldWidget extends WidgetType {
                 },
             });
 
-            renderCompactMarkdown(this.app, this.field.key, key, this.sourcePath, this.component);
+            renderCompactMarkdown(this.app, this.field.key, key, this.sourcePath, this.component, true);
 
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-value"],
             });
-
             renderValue(
                 this.app,
                 parseInlineValue(this.field.value),
@@ -260,7 +259,6 @@ class InlineFieldWidget extends WidgetType {
             const value = renderContainer.createSpan({
                 cls: ["dataview", "inline-field-standalone-value"],
             });
-
             renderValue(
                 this.app,
                 parseInlineValue(this.field.value),


### PR DESCRIPTION
This reverts commit 6a6e0251e842e5395a13853d18ef41c0ffb249b6.



I had previously made a PR to "[Fix inline list rendering in live preview](https://github.com/blacksmithgu/obsidian-dataview/pull/2387)". Although the PR does do this, after more thorough testing, I have realized that my merged change also slows down loading times of larger notes that have many inline properties. I strive to make fixes and improvements that will not incur any such negative consequences. ~~While I am looking into a better fix, I would like to revert my change in the meantime to prevent this from going into the next release.~~

### Edit
I have come across a solution that resolves displaying lists within live preview without any performance impact. I added the better fix to this branch.  


Link to previous issues, for reference: https://github.com/blacksmithgu/obsidian-dataview/issues/2385, https://github.com/blacksmithgu/obsidian-dataview/issues/2281. 


