### PR TITLE
Fix broken sources link

### DIFF
--- a/docs/docs/queries/data-commands.md
+++ b/docs/docs/queries/data-commands.md
@@ -7,7 +7,7 @@ blocks or multiple `GROUP BY` blocks, for example).
 ## FROM
 
 The `FROM` statement determines what pages will initially be collected and passed onto the other commands for further
-filtering. You can select from any [source](../reference/sources), which currently means by folder, by tag, or by incoming/outgoing links.
+filtering. You can select from any [source](../reference/sources.md), which currently means by folder, by tag, or by incoming/outgoing links.
 
 - **Tags**: To select from a tag (and all its subtags), use `FROM #tag`.
 - **Folders**: To select from a folder (and all its subfolders), use `FROM "folder"`.


### PR DESCRIPTION
The "sources" link from the Data Commands page is broken. Just missing the `.md` from the end.