### PR TITLE
Fix inline query documentation

### DIFF
--- a/docs/docs/queries/dql-js-inline.md
+++ b/docs/docs/queries/dql-js-inline.md
@@ -49,7 +49,7 @@ would, for example, render to
 Today is November 07, 2022 - 2 months, 5 days until exams!
 ~~~
 
-**Inline DQL** queries always display exactly one value, not a list (or table) of values. You can access the properties of the **current page** via prefix `this.` or a different page via `[[linkToPage]]`.
+**Inline DQL** queries always display exactly one value, not a list (or table) of values. You can access the properties of the **current page** via prefix `this.` or a different page via `[[linkToPage]].`.
 
 ~~~markdown
 `= this.file.name`

--- a/docs/docs/queries/dql-js-inline.md
+++ b/docs/docs/queries/dql-js-inline.md
@@ -49,7 +49,7 @@ would, for example, render to
 Today is November 07, 2022 - 2 months, 5 days until exams!
 ~~~
 
-**Inline DQL** cannot query multiple pages. They always display exactly one value, not a list (or table) of values. You can either access the properties of the **current page** via prefix `this.` or a different page via `[[linkToPage]]`.
+**Inline DQL** queries always display exactly one value, not a list (or table) of values. You can either access the properties of the **current page** via prefix `this.` or a different page via `[[linkToPage]]`.
 
 ~~~markdown
 `= this.file.name`

--- a/docs/docs/queries/dql-js-inline.md
+++ b/docs/docs/queries/dql-js-inline.md
@@ -49,7 +49,7 @@ would, for example, render to
 Today is November 07, 2022 - 2 months, 5 days until exams!
 ~~~
 
-**Inline DQL** queries always display exactly one value, not a list (or table) of values. You can either access the properties of the **current page** via prefix `this.` or a different page via `[[linkToPage]]`.
+**Inline DQL** queries always display exactly one value, not a list (or table) of values. You can access the properties of the **current page** via prefix `this.` or a different page via `[[linkToPage]]`.
 
 ~~~markdown
 `= this.file.name`


### PR DESCRIPTION
Unless I'm misinterpreting, the current documentation is inaccurate as Inline DQL can query multiple pages. A quick example I tested on the latest version:

![image](https://github.com/user-attachments/assets/5aa650a9-eb83-4640-a916-0b3bed9f29d9)
![image](https://github.com/user-attachments/assets/910565be-70ec-42ee-b75d-26961551f8cd)

resolves fine despite Blackberry and Lemon being different pages. 

Removed this statement from the paragraph.