### PR TITLE
Super tiny fix broken link

### DIFF
--- a/docs/docs/reference/sources.md
+++ b/docs/docs/reference/sources.md
@@ -1,7 +1,7 @@
 # Sources
 
 A dataview **source** is something that identifies a set of files, tasks, or other data. Sources are indexed internally by
-Dataview, so they are fast to query. The most prominent use of sources is the [FROM data command](../queries#from). They are also used in various JavaScript API query calls.
+Dataview, so they are fast to query. The most prominent use of sources is the [FROM data command](../queries/data-commands#from). They are also used in various JavaScript API query calls.
 
 ## Types of Sources
 


### PR DESCRIPTION
Hi thanks for the project! When reading doc, it seems a link is broken:

![image](https://github.com/user-attachments/assets/06c0c2d6-c6bc-4e42-802e-89998cbd2a1e)
![image](https://github.com/user-attachments/assets/ca05dab3-befa-4e31-b639-86e44e475f22)

while the correct one seems https://blacksmithgu.github.io/obsidian-dataview/queries/data-commands/#from