### PR TITLE
Add Function to convert data types to their display value

### DIFF
--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -704,6 +704,23 @@ default(list(1, 2, null), 3) = list(1, 2, 3)
 ldefault(list(1, 2, null), 3) = list(1, 2, null)
 ```
 
+### `display()`
+
+Display function converts the input into a string representation while trying to
+preserve the display property of data types.
+This means that links and urls will be replaced by their display value.
+
+
+```js
+display("Hello World") = "Hello World"
+display("**Hello** World") = "Hello World"
+display("[Hello](https://example.com) [[World]]") = "Hello World"
+display(link("path/to/file.md")) = "file"
+display(link("path/to/file.md", "displayname")) = "displayname"
+display(date("2024-11-18")) = "November 18, 2024"
+display(list("Hello", "World")) = "Hello, World"
+```
+
 ### `choice(bool, left, right)`
 
 A primitive if statement - if the first argument is truthy, returns left; otherwise, returns right.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "obsidian-calendar-ui": "^0.3.12",
     "papaparse": "^5.3.1",
     "parsimmon": "^1.18.0",
-    "preact": "^10.6.5"
+    "preact": "^10.6.5",
+    "remove-markdown": "^0.5.5"
   }
 }

--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -557,25 +557,6 @@ export namespace DefaultFunctions {
         .add1("*", e => e)
         .build();
 
-    // Returns the display name of the element.
-    export const display = new FunctionBuilder("display")
-        .add1("null", (): Literal => "")
-        .add1("array", (a: Literal[], ctx: Context): Literal => {
-            return a.map(e => display(ctx, e)).join(", ");  
-        })
-        .add1("string", (str: string): Literal => normalizeMarkdown(str))
-        .add1("link", (a: Link, ctx: Context): Literal => {
-            if (a.display) {
-                return display(ctx, a.display);
-            } else {
-                return Values.toString(a, ctx.settings).replace(/\[\[.*\|(.*)\]\]/, "$1") 
-            }
-        })
-        .add1("*", (a: Literal, ctx: Context): Literal => {
-            return Values.toString(a, ctx.settings);
-        })
-        .build();
-
     export const regextest = new FunctionBuilder("regextest")
         .add2("string", "string", (pattern: string, field: string) => RegExp(pattern).test(field))
         .add2("null", "*", (_n, _a) => false)
@@ -718,6 +699,25 @@ export namespace DefaultFunctions {
 
     export const ldefault = new FunctionBuilder("ldefault")
         .add2("*", "*", (v, bk) => (Values.isNull(v) ? bk : v))
+        .build();
+
+    // Returns the display name of the element.
+    export const display = new FunctionBuilder("display")
+        .add1("null", (): Literal => "")
+        .add1("array", (a: Literal[], ctx: Context): Literal => {
+            return a.map(e => display(ctx, e)).join(", ");  
+        })
+        .add1("string", (str: string): Literal => normalizeMarkdown(str))
+        .add1("link", (a: Link, ctx: Context): Literal => {
+            if (a.display) {
+                return display(ctx, a.display);
+            } else {
+                return Values.toString(a, ctx.settings).replace(/\[\[.*\|(.*)\]\]/, "$1") 
+            }
+        })
+        .add1("*", (a: Literal, ctx: Context): Literal => {
+            return Values.toString(a, ctx.settings);
+        })
         .build();
 
     export const choice = new FunctionBuilder("choice")
@@ -932,7 +932,6 @@ export const DEFAULT_FUNCTIONS: Record<string, FunctionImpl> = {
     reduce: DefaultFunctions.reduce,
 
     // String Operations
-    display: DefaultFunctions.display,
     regextest: DefaultFunctions.regextest,
     regexmatch: DefaultFunctions.regexmatch,
     regexreplace: DefaultFunctions.regexreplace,
@@ -950,6 +949,7 @@ export const DEFAULT_FUNCTIONS: Record<string, FunctionImpl> = {
     // Utility Operations
     default: DefaultFunctions.fdefault,
     ldefault: DefaultFunctions.ldefault,
+    display: DefaultFunctions.display,
     choice: DefaultFunctions.choice,
     striptime: DefaultFunctions.striptime,
     dateformat: DefaultFunctions.dateformat,

--- a/src/test/function/functions.test.ts
+++ b/src/test/function/functions.test.ts
@@ -104,6 +104,25 @@ describe("sort()", () => {
     });
 });
 
+// <-- display() -->
+
+test("Evaluate display()", () => {
+    expect(parseEval('display("test")')).toEqual("test");
+    expect(parseEval('display("[displayname](http://example.com)")')).toEqual("displayname");
+    expect(parseEval('display("[[test]]")')).toEqual("test");
+    expect(parseEval('display("[[test|displayname]]")')).toEqual("displayname");
+    expect(parseEval('display("long [[test]] **with** [[test2|multiple]] [links](http://example.com)")')).toEqual("long test with multiple links");
+    expect(parseEval('display(1)')).toEqual("1");
+    expect(parseEval('display(true)')).toEqual("true");
+    expect(parseEval('display(null)')).toEqual("");
+    expect(parseEval('display(date("2024-11-18"))')).toEqual("November 18, 2024");
+    expect(parseEval('display(dur("7 hours"))')).toEqual("7 hours");
+    expect(parseEval('display(link("path/to/file.md"))')).toEqual("file");
+    expect(parseEval('display(link("path/to/file.md", "displayname"))')).toEqual("displayname");
+    expect(parseEval('display(list("test", 2, link("file.md")))')).toEqual('test, 2, file');
+});
+
+
 // <-- default() -->
 
 test("Evaluate default()", () => {

--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -3,6 +3,7 @@ import { Result } from "api/result";
 import * as P from "parsimmon";
 import emojiRegex from "emoji-regex";
 import { QuerySettings } from "settings";
+import removeMd from "remove-markdown";
 
 /** Normalize a duration to all of the proper units. */
 export function normalizeDuration(dur: Duration) {
@@ -158,4 +159,18 @@ export function setsEqual<T>(first: Set<T>, second: Set<T>): boolean {
     for (let elem of first) if (!second.has(elem)) return false;
 
     return true;
+}
+
+/** Normalize a markdown string. Removes all markdown tags and obsidian links. */
+export function normalizeMarkdown(str: string): string {
+    // [[test]] -> test
+    let interim = str.replace(/\[\[([^\|]*?)\]\]/g, "$1")
+
+    // [[test|test]] -> test
+    interim = interim.replace(/\[\[.*?\|(.*?)\]\]/, "$1")
+    
+    // remove markdown tags
+    interim = removeMd(interim);
+
+    return interim
 }


### PR DESCRIPTION
Querying for metadata where only the "display" version is currently complicated.

Consider these three metadata fields:

```markdown
(author:: Jon Doe)
(author:: [[Jon Doe]])
(author:: [Jon Doe](https://example.com))
```

The query

```
TABLE author
FLATTEN author
WHERE author = "Jon Doe"
```

only results in the first match:
| File | Author |
|--|--|
| test | Jon Doe |

The only query I found that matched all three cases was this one:

```dataview
TABLE author
FLATTEN author
WHERE contains(string(author), "Jon Doe")
```

| File | Author |
|--|--|
| test | Jon Doe |
| test | Jon Doe |
| test | Jon Doe |

However, this expression is error-prone and quite complicated. This PR introduces a new utility function `display()` that tries to convert all objects into a valid string representation while preserving the display value. This means `[[Jon Doe]]` is converted to "Jon Doe" and `[[Jon Doe|Joe]]` is converted to "Jon", etc. The above query reduces to this much simpler expression:

```dataview
TABLE author
FLATTEN author
WHERE display(author) = "Jon Doe"
```