### PR TITLE
feat: add ability to set default month for calendar

### DIFF
--- a/docs/docs/queries/query-types.md
+++ b/docs/docs/queries/query-types.md
@@ -486,3 +486,14 @@ CALENDAR due
 WHERE typeof(due) = "date"
 ```
 ~~~
+
+### CALENDAR DEFAULT MONTH
+
+If you want to focus the calendar on a particular month (instead of the current month), you can use `CALENDAR DEFAULT MONTH`.
+
+~~~
+```dataview
+CALENDAR file.ctime
+DEFAULT MONTH 2024-11
+```
+~~~

--- a/src/query/engine.ts
+++ b/src/query/engine.ts
@@ -489,6 +489,8 @@ export async function executeCalendar(
         link: Fields.indexVariable("file.link"),
     };
 
+    let displayedMonth = (query.header as CalendarQuery).displayedMonth;
+
     return executeCoreExtract(fileset.value, rootContext, query.operations, fields).map(core => {
         let data = core.data.map(p =>
             iden({
@@ -497,11 +499,12 @@ export async function executeCalendar(
             })
         );
 
-        return { core, data };
+        return { core, data, displayedMonth };
     });
 }
 
 export interface CalendarExecution {
     core: CoreExecution;
     data: { date: DateTime; link: Link; value?: Literal[] }[];
+    displayedMonth?: DateTime;
 }

--- a/src/query/parse.ts
+++ b/src/query/parse.ts
@@ -153,11 +153,20 @@ export const QUERY_LANGUAGE = P.createLanguage<QueryLanguageTypes>({
                         return P.succeed({ type });
                     case "calendar":
                         return P.whitespace.then(
-                            P.seqMap(q.namedField, field => {
+                            P.seqMap(
+                                q.namedField,
+                                P.whitespace
+                                    .then(P.regexp(/DEFAULT\s+MONTH/i))
+                                    .then(P.whitespace)
+                                    .then(EXPRESSION.date)
+                                    .skip(P.optWhitespace)
+                                    .atMost(1),
+                                (field, month) => {
                                 return {
                                     type,
                                     showId: true,
                                     field,
+                                    displayedMonth: month.length == 1 ? month[0] : undefined,
                                 } as QueryHeader;
                             })
                         );

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -1,6 +1,7 @@
 /** Provides an AST for complex queries. */
 import { Source } from "data-index/source";
 import { Field } from "expression/field";
+import { DateTime } from "luxon";
 
 /** The supported query types (corresponding to view types). */
 export type QueryType = "list" | "table" | "task" | "calendar";
@@ -67,6 +68,7 @@ export interface CalendarQuery {
     type: "calendar";
     /** The date field that we'll be grouping notes by for the calendar view */
     field: NamedField;
+    displayedMonth?: DateTime;
 }
 
 export type QueryHeader = ListQuery | TableQuery | TaskQuery | CalendarQuery;

--- a/src/ui/views/calendar-view.ts
+++ b/src/ui/views/calendar-view.ts
@@ -8,7 +8,7 @@ import { DataviewSettings } from "settings";
 import { renderErrorPre } from "ui/render";
 import { DataviewRefreshableRenderer } from "ui/refreshable-view";
 import { asyncTryOrPropagate } from "util/normalize";
-import type { Moment } from "moment";
+import { default as moment, type Moment } from "moment";
 
 // CalendarFile is a representation of a particular file, displayed in the calendar view.
 // It'll be represented in the calendar as a dot.
@@ -99,6 +99,7 @@ export class DataviewCalendarRenderer extends DataviewRefreshableRenderer {
                 },
                 showWeekNums: false,
                 sources,
+                displayedMonth: moment(maybeResult.value.displayedMonth?.toISO()),
             },
         });
     }

--- a/test-vault/example calendars.md
+++ b/test-vault/example calendars.md
@@ -1,6 +1,6 @@
-
 ```dataview
 CALENDAR thoughtOfDate
+DEFAULT MONTH 2021-12
 FROM
 "recipes"
 ```


### PR DESCRIPTION
Resolves #1810 

Adds the ability to set a default month for the calendar query, e.g.

```dataview
CALENDAR file.ctime
DEFAULT MONTH 2021-12
```