### PR TITLE
fix wrong links throughout the docs

### DIFF
--- a/docs/docs/annotation/add-metadata.md
+++ b/docs/docs/annotation/add-metadata.md
@@ -30,9 +30,9 @@ Frontmatter is a common Markdown extension which allows for YAML metadata to be 
 
 With this your note has metadata fields named `alias`, `last-reviewed`, and `thoughts`. Each of these have different **data types**:
 
-- `alias` is a [text](../types-of-metadata/#text), because its wrapped in ""
-- `last-reviewed` is a [date](../types-of-metadata/#date), because it follows the ISO date format
-- `thoughts` is a [object](../types-of-metadata/#object) field, because it uses the YAML Frontmatter object syntax
+- `alias` is a [text](types-of-metadata.md#text), because its wrapped in ""
+- `last-reviewed` is a [date](types-of-metadata.md#date), because it follows the ISO date format
+- `thoughts` is a [object](types-of-metadata.md#object) field, because it uses the YAML Frontmatter object syntax
 
 You could query for this note with the following query:
 

--- a/docs/docs/annotation/metadata-tasks.md
+++ b/docs/docs/annotation/metadata-tasks.md
@@ -1,6 +1,6 @@
 # Metadata on Tasks and Lists
 
-Just like pages, you can also add **fields** on list item and task level to bind it to a specific task as context. For this you need to use the [inline field syntax](../add-metadata/#inline-fields):
+Just like pages, you can also add **fields** on list item and task level to bind it to a specific task as context. For this you need to use the [inline field syntax](add-metadata.md#inline-fields):
 
 ```markdown
 - [ ] Hello, this is some [metadata:: value]!
@@ -88,7 +88,7 @@ With usage of the [shorthand syntax](#field-shorthands), following additional pr
 
 ### Accessing Implicit Fields in Queries
 
-If you're using a [TASK](../queries/query-types.md#task-queries) Query, your tasks are the top level information and can be used without any prefix:
+If you're using a [TASK](../queries/query-types.md#task) Query, your tasks are the top level information and can be used without any prefix:
 
 ~~~markdown
 ```dataview

--- a/docs/docs/annotation/types-of-metadata.md
+++ b/docs/docs/annotation/types-of-metadata.md
@@ -118,10 +118,10 @@ WHERE birthday.month = date(now).month
 ```
 ~~~
 
-gives you back all birthdays happening this month. Curious about `date(now)`? Read more about it under [literals](./../../reference/literals/#dates).
+gives you back all birthdays happening this month. Curious about `date(now)`? Read more about it under [literals](../reference/literals.md#dates).
 
 !!! info "Displaying of date objects"
-    Dataview renders date objects in a human readable format, i.e. `3:15 PM - February 26, 2021`. You can adjust how this format looks like in Dataview's Setting under "General" with "Date Format" and "Date + Time Format". If you want to adjust the format in a specific query only, use the [dateformat function](../../reference/functions/#dateformatdatedatetime-string).
+    Dataview renders date objects in a human readable format, i.e. `3:15 PM - February 26, 2021`. You can adjust how this format looks like in Dataview's Setting under "General" with "Date Format" and "Date + Time Format". If you want to adjust the format in a specific query only, use the [dateformat function](../reference/functions.md#dateformatdatedatetime-string).
 
 ### Duration
 
@@ -137,7 +137,7 @@ Example:: 9 years, 8 months, 4 days, 16 hours, 2 minutes
 Example:: 9 yrs 8 min
 ```
 
-Find the complete list of values that are recognized as a duration on [literals](./../../reference/literals/#durations). 
+Find the complete list of values that are recognized as a duration on [literals](../reference/literals.md#durations). 
 
 !!! hint "Calculations with dates and durations"
     Date and Duration types are compatible with each other. This means you can, for example, add durations to a date to produce a new date:
@@ -155,7 +155,7 @@ Find the complete list of values that are recognized as a duration on [literals]
     `= this.release-date - date(now)` until release!!
     ~~~
 
-    Curious about `date(now)`? Read more about it under [literals](./../../reference/literals/#dates).
+    Curious about `date(now)`? Read more about it under [literals](../reference/literals.md#dates).
 
 ### Link
 

--- a/docs/docs/api/code-reference.md
+++ b/docs/docs/api/code-reference.md
@@ -22,8 +22,8 @@ Get page information (via `dv.page()`) for the page the script is currently exec
 
 ### `dv.pages(source)`
 
-Take a single string argument, `source`, which is the same form as a [query language source](../../reference/sources).
-Return a [data array](../data-array) of page objects, which are plain objects with all of the page fields as
+Take a single string argument, `source`, which is the same form as a [query language source](../reference/sources.md).
+Return a [data array](data-array.md) of page objects, which are plain objects with all of the page fields as
 values.
 
 ```js
@@ -39,7 +39,7 @@ Note that folders need to be double-quoted inside the string (i.e., `dv.pages("f
 
 ### `dv.pagePaths(source)`
 
-As with `dv.pages`, but just returns a [data array](../data-array) of paths of pages that match the given source.
+As with `dv.pages`, but just returns a [data array](data-array.md) of paths of pages that match the given source.
 
 ```js
 dv.pagePaths("#books") => the paths of pages with tag 'books'
@@ -277,7 +277,7 @@ dv.paragraph(markdown);
 
 ### `dv.array(value)`
 
-Convert a given value or array into a Dataview [data array](../data-array). If the value is already a data array, returns
+Convert a given value or array into a Dataview [data array](data-array.md). If the value is already a data array, returns
 it unchanged.
 
 ```js

--- a/docs/docs/api/intro.md
+++ b/docs/docs/api/intro.md
@@ -16,10 +16,10 @@ dv.pages("#thing")...
 
 Code executed in such codeblocks have access to the `dv` variable, which provides the entirety of the codeblock-relevant
 dataview API (like `dv.table()`, `dv.pages()`, and so on). For more information, check out the [codeblock API
-reference](../code-reference/).
+reference](code-reference.md).
 
 ## Plugin Access
 
 You can access the Dataview Plugin API (from other plugins or the console) through `app.plugins.plugins.dataview.api`;
 this API is similar to the codeblock reference, with slightly different arguments due to the lack of an implicit file
-to execute the queries in. For more information, check out the [Plugin API reference](../code-reference/).
+to execute the queries in. For more information, check out the [Plugin API reference](code-reference.md).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -16,11 +16,11 @@ and many more things.
 
 Dataview is highly generic and high performance, scaling up to hundreds of thousands of annotated notes without issue. 
 
-If the built in [query language](query/queries/) is insufficient for your purpose, you can run arbitrary
-JavaScript against the [dataview API](api/intro/) and build whatever utility you might need yourself, right in your notes.
+If the built in [query language](queries/structure.md) is insufficient for your purpose, you can run arbitrary
+JavaScript against the [dataview API](api/intro.md) and build whatever utility you might need yourself, right in your notes.
 
 !!! info "Dataview is about displaying, not editing"
-    Dataview is meant for displaying and calculating data. It is not meant to edit your notes/metadata and will always leave them untouched (... except if you're checking a [Task](queries/query-types.md#task-queries) through Dataview.)
+    Dataview is meant for displaying and calculating data. It is not meant to edit your notes/metadata and will always leave them untouched (... except if you're checking a [Task](queries/query-types.md#task) through Dataview.)
 
 ## How to Use Dataview
 
@@ -72,14 +72,14 @@ In terms of indexed metadata (or what you can query), they are identical, and on
 
 You can access **indexed data** with the help of **Queries**.
 
-There are **three different ways** you can write a Query: With help of the [Dataview Query Language](queries/dql-js-inline/#dataview-query-language-dql), as an [inline statement](queries/dql-js-inline#inline-dql) or in the most flexible but most complex way: as a [Javascript Query](queries/dql-js-inline#dataview-js). 
+There are **three different ways** you can write a Query: With help of the [Dataview Query Language](queries/dql-js-inline.md#dataview-query-language-dql), as an [inline statement](queries/dql-js-inline.md#inline-dql) or in the most flexible but most complex way: as a [Javascript Query](queries/dql-js-inline.md#dataview-js). 
 
-The **Dataview Query Language** (**DQL**) gives you a broad and powerful toolbelt to query, display and operate on your data. An [**inline query**](queries/dql-js-inline#inline-dql) gives you the possibility to display exactly one indexed value anywhere in your note. You can also do calculations this way. With **DQL** at your hands, you'll be probably fine without any Javascript through your data journey.
+The **Dataview Query Language** (**DQL**) gives you a broad and powerful toolbelt to query, display and operate on your data. An [**inline query**](queries/dql-js-inline.md#inline-dql) gives you the possibility to display exactly one indexed value anywhere in your note. You can also do calculations this way. With **DQL** at your hands, you'll be probably fine without any Javascript through your data journey.
 
 A DQL Query consists of several parts:
 
 - Exactly one [**Query Type**](queries/query-types.md) that determines what your Query Output looks like
-- None or one [**FROM statement**](queries/data-commands#from) to pick a specific tag or folder (or another [source](reference/sources.md)) to look at
+- None or one [**FROM statement**](queries/data-commands.md#from) to pick a specific tag or folder (or another [source](reference/sources.md)) to look at
 - None to multiple [**other Data Commands**](queries/data-commands.md) that help you filter, group and sort your wanted output
 
 For example, a Query can look like this:
@@ -93,7 +93,7 @@ LIST
 which list all files in your vault. 
 
 !!! info "Everything but the Query Type is optional"
-    The only thing you need for a valid DQL Query is the Query Type (and on [CALENDAR](queries/query-types#calendar-queries)s, a date field.)
+    The only thing you need for a valid DQL Query is the Query Type (and on [CALENDAR](queries/query-types.md#calendar)s, a date field.)
 
  A more restricted Query might look like this:
 

--- a/docs/docs/queries/data-commands.md
+++ b/docs/docs/queries/data-commands.md
@@ -7,7 +7,7 @@ blocks or multiple `GROUP BY` blocks, for example).
 ## FROM
 
 The `FROM` statement determines what pages will initially be collected and passed onto the other commands for further
-filtering. You can select from any [source](../reference/sources), which currently means by folder, by tag, or by incoming/outgoing links.
+filtering. You can select from any [source](../reference/sources.md), which currently means by folder, by tag, or by incoming/outgoing links.
 
 - **Tags**: To select from a tag (and all its subtags), use `FROM #tag`.
 - **Folders**: To select from a folder (and all its subfolders), use `FROM "folder"`.

--- a/docs/docs/queries/differences-to-sql.md
+++ b/docs/docs/queries/differences-to-sql.md
@@ -1,3 +1,11 @@
+<!--
+ * @Author: chinesehamburger 2576226012@qq.com
+ * @Date: 2024-12-12 14:24:45
+ * @LastEditors: chinesehamburger 2576226012@qq.com
+ * @LastEditTime: 2024-12-13 16:40:43
+ * @FilePath: \obsidian-dataview\docs\docs\queries\differences-to-sql.md
+ * @Description: 这是默认设置,请设置`customMade`, 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+-->
 # Dataview Query Language (DQL) and SQL
 
 If you are familiar with SQL and experienced in writing SQL queries, you might approach writing a DQL query in a similar way. However, DQL is significantly different from SQL.
@@ -12,7 +20,7 @@ Instead of starting with SELECT, a DQL query starts with a word determining the 
 
 The next line starts with FROM which is not followed by a table name but by a complex expression, similar to an SQL WHERE clause. Here you can filter on many things, like tags in files, file names, path names, etc. In the background, this command already produces a result set which will be our initial set for further data manipulation by 'data commands' on subsequent lines.
 
-You can have as many following lines as you want. Each will start with a [data command](../../queries/data-commands) and will re-shape the result set it received from the previous line. For example:
+You can have as many following lines as you want. Each will start with a [data command](data-commands.md) and will re-shape the result set it received from the previous line. For example:
 
 - The WHERE data command will only keep those lines from the result set which match a given condition. This means that, unless all data in the result set matches the condition, this command will pass on a smaller result set to the next line than it received from the previous line. Unlike in SQL, you can have as many WHERE commands as you like.
 - The FLATTEN data command is not found in common SQL but in DQL you can use it to reduce the depth of the result set.

--- a/docs/docs/queries/dql-js-inline.md
+++ b/docs/docs/queries/dql-js-inline.md
@@ -6,10 +6,10 @@ when your vault changes.
 
 ## Dataview Query Language (DQL)
 
-The [**Dataview Query Language**](../../queries/structure) (for short **DQL**) is a SQL-like language and Dataviews core functionality. It supports [four Query Types](./query-types.md) to produce different outputs, [data commands](./data-commands.md) to refine, resort or group your result and [plentiful functions](../reference/functions.md) which allow numerous operations and adjustments to achieve your wanted output.
+The [**Dataview Query Language**](structure.md) (for short **DQL**) is a SQL-like language and Dataviews core functionality. It supports [four Query Types](./query-types.md) to produce different outputs, [data commands](./data-commands.md) to refine, resort or group your result and [plentiful functions](../reference/functions.md) which allow numerous operations and adjustments to achieve your wanted output.
 
 !!! warning Differences to SQL
-    If you are familiar with SQL, please read [Differences to SQL](../../queries/differences-to-sql) to avoid confusing DQL with SQL.
+    If you are familiar with SQL, please read [Differences to SQL](differences-to-sql.md) to avoid confusing DQL with SQL.
 
 You create a **DQL** query with a codeblock that uses `dataview` as type:
 
@@ -24,7 +24,7 @@ SORT rating DESC
     A valid codeblock needs to use backticks (\`) on start and end (three each). Do not confuse the backtick with the similar looking apostrophe ' !
 
 Find a explanation how to write a DQL Query under the [query language
-reference](../../queries/structure). If you learn better by example, take a look at the [query examples](../../resources/examples).
+reference](structure.md). If you learn better by example, take a look at the [query examples](../resources/examples.md).
 
 ## Inline DQL
 
@@ -60,7 +60,7 @@ Today is November 07, 2022 - 2 months, 5 days until exams!
 `= [[secondPage]].someMetadataField`
 ~~~
 
-You can use everything available as [expressions](../../reference/expressions) and [literals](../../reference/literals) in an Inline DQL Query, including [functions](../../reference/functions). Query Types and Data Commands, on the other hand, are **not available in Inlines.**
+You can use everything available as [expressions](../reference/expressions.md) and [literals](../reference/literals.md) in an Inline DQL Query, including [functions](../reference/functions.md). Query Types and Data Commands, on the other hand, are **not available in Inlines.**
 
 ~~~markdown
 Assignment due in `= this.due - date(today)`
@@ -73,7 +73,7 @@ You have `= length(filter(link(dateformat(date(today), "yyyy-MM-dd")).file.tasks
 
 ## Dataview JS
 
-The dataview [JavaScript API](../../api/intro) gives you the full power of JavaScript and provides a DSL for pulling
+The dataview [JavaScript API](../api/intro.md) gives you the full power of JavaScript and provides a DSL for pulling
 Dataview data and executing queries, allowing you to create arbitrarily complex queries and views. Similar to the query
 language, you create Dataview JS blocks via a `dataviewjs`-annotated codeblock:
 
@@ -88,8 +88,8 @@ for (let group of pages.groupBy(b => b.genre)) {
 ~~~
 
 Inside of a JS dataview block, you have access to the full dataview API via the `dv` variable. For an explanation of
-what you can do with it, see the [API documentation](../../api/code-reference), or the [API
-examples](../../api/code-examples).
+what you can do with it, see the [API documentation](../api/code-reference.md), or the [API
+examples](../api/code-examples.md).
 
 !!! attention "Advanced usage"
     Writing Javascript queries is a advanced technique that requires understanding in programming and JS. Please be aware that JS Queries have access to your file system and be cautious when using other peoples' JS Queries, especially when they are not publicly shared through the Obsidian Community.

--- a/docs/docs/queries/structure.md
+++ b/docs/docs/queries/structure.md
@@ -16,7 +16,7 @@ supports:
 - **Limiting** your result count
 
 !!! warning Differences to SQL
-    If you are familiar with SQL, please read [Differences to SQL](../../queries/differences-to-sql) to avoid confusing DQL with SQL.
+    If you are familiar with SQL, please read [Differences to SQL](differences-to-sql.md) to avoid confusing DQL with SQL.
 
 Let's have a look at how we can put DQL to use.
 
@@ -84,7 +84,7 @@ TABLE due, file.tags AS "tags", average(working-hours)
 
 ## Choose your source
 
-Additionally to the Query Types, you have several **Data Commands** available that help you restrict, refine, sort or group your query. One of these query commands is the **FROM** statement. `FROM` takes a [source](../../reference/sources) or a combination of [sources](../../reference/sources) as an argument and restricts the query to a set of pages that match your source.
+Additionally to the Query Types, you have several **Data Commands** available that help you restrict, refine, sort or group your query. One of these query commands is the **FROM** statement. `FROM` takes a [source](../reference/sources.md) or a combination of [sources](../reference/sources.md) as an argument and restricts the query to a set of pages that match your source.
 
 It behaves differently from the other Data Commands: You can add **zero or one** `FROM` data command to your query, right after your Query Type. You cannot add multiple FROM statements and you cannot add it after other Data Commands.
 

--- a/docs/docs/reference/expressions.md
+++ b/docs/docs/reference/expressions.md
@@ -174,7 +174,7 @@ TABLE id, episode_metadata.next, aliases[0]
 ### Function Calls
 
 Dataview supports various functions for manipulating data, which are described in full in the [functions
-documentation](../functions). They have the general syntax `function(arg1, arg2, ...)` - i.e., `lower(file.name)` or
+documentation](functions.md). They have the general syntax `function(arg1, arg2, ...)` - i.e., `lower(file.name)` or
 `regexmatch("A.+", file.folder)`.
 
 ~~~

--- a/docs/docs/reference/literals.md
+++ b/docs/docs/reference/literals.md
@@ -60,7 +60,7 @@ Literal|Description
 
 ### Dates
 
-Whenever you use a [field value in Date ISO format](../annotation/types-of-metadata.md#date), you'll need to compare these fields against date objects. Dataview provides some shorthands for common use cases like tomorrow, start of current week etc. Please note that `date()` is also a [function](../functions/#dateany), which can be called on **text** to extract dates.
+Whenever you use a [field value in Date ISO format](../annotation/types-of-metadata.md#date), you'll need to compare these fields against date objects. Dataview provides some shorthands for common use cases like tomorrow, start of current week etc. Please note that `date()` is also a [function](functions.md#dateany), which can be called on **text** to extract dates.
 
 Literal|Description
 -|-

--- a/docs/docs/reference/sources.md
+++ b/docs/docs/reference/sources.md
@@ -1,7 +1,7 @@
 # Sources
 
 A dataview **source** is something that identifies a set of files, tasks, or other data. Sources are indexed internally by
-Dataview, so they are fast to query. The most prominent use of sources is the [FROM data command](../queries/data-commands#from). They are also used in various JavaScript API query calls.
+Dataview, so they are fast to query. The most prominent use of sources is the [FROM data command](../queries/data-commands.md#from). They are also used in various JavaScript API query calls.
 
 ## Types of Sources
 

--- a/docs/docs/resources/faq.md
+++ b/docs/docs/resources/faq.md
@@ -30,7 +30,7 @@ Yes! Please see the [Resources](../resources/resources-and-support.md) page.
 
 ### Can I save the result of a query for reusability?
 
-You can write reusable Javascript Queries with the [dv.view](../../api/code-reference/#dvviewpath-input) function. In DQL, beside the possibility of writing your Query inside a Template and using this template (either with the [Core Plugin Templates](https://help.obsidian.md/Plugins/Templates) or the popular Community Plugin [Templater](https://obsidian.md/plugins?id=templater-obsidian)), you can **save calculations in metadata fields via [Inline DQL](../../queries/dql-js-inline#inline-dql)**, for example:
+You can write reusable Javascript Queries with the [dv.view](../api/code-reference.md#dvviewpath-input) function. In DQL, beside the possibility of writing your Query inside a Template and using this template (either with the [Core Plugin Templates](https://help.obsidian.md/Plugins/Templates) or the popular Community Plugin [Templater](https://obsidian.md/plugins?id=templater-obsidian)), you can **save calculations in metadata fields via [Inline DQL](../queries/dql-js-inline.md#inline-dql)**, for example:
 
 ```markdown
 start:: 07h00m


### PR DESCRIPTION
when I use `mkdocs serve`, I got these information:
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'query/queries/', it was left as is.
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'api/intro/', it was left as is. Did you mean 'api/intro.md'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'queries/dql-js-inline/#dataview-query-language-dql', it was left as is. Did you mean
           'queries/dql-js-inline.md#dataview-query-language-dql'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'queries/dql-js-inline#inline-dql', it was left as is. Did you mean 'queries/dql-js-inline.md#inline-dql'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'queries/dql-js-inline#dataview-js', it was left as is. Did you mean 'queries/dql-js-inline.md#dataview-js'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'queries/dql-js-inline#inline-dql', it was left as is. Did you mean 'queries/dql-js-inline.md#inline-dql'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'queries/data-commands#from', it was left as is. Did you mean 'queries/data-commands.md#from'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'queries/query-types#calendar-queries', it was left as is. Did you mean 'queries/query-types.md#calendar-queries'?
INFO    -  Doc file 'changelog.md' contains an unrecognized relative link 'to', it was left as is.
INFO    -  Doc file 'annotation/add-metadata.md' contains an unrecognized relative link '../types-of-metadata/#text', it was left as is. Did you mean 'types-of-metadata.md#text'?
INFO    -  Doc file 'annotation/add-metadata.md' contains an unrecognized relative link '../types-of-metadata/#date', it was left as is. Did you mean 'types-of-metadata.md#date'?
INFO    -  Doc file 'annotation/add-metadata.md' contains an unrecognized relative link '../types-of-metadata/#object', it was left as is. Did you mean 'types-of-metadata.md#object'?
INFO    -  Doc file 'annotation/metadata-tasks.md' contains an unrecognized relative link '../add-metadata/#inline-fields', it was left as is. Did you mean 'add-metadata.md#inline-fields'?
INFO    -  Doc file 'annotation/types-of-metadata.md' contains an unrecognized relative link './../../reference/literals/#dates', it was left as is. Did you mean '../reference/literals.md#dates'?
INFO    -  Doc file 'annotation/types-of-metadata.md' contains an unrecognized relative link '../../reference/functions/#dateformatdatedatetime-string', it was left as is. Did you mean
           '../reference/functions.md#dateformatdatedatetime-string'?
INFO    -  Doc file 'annotation/types-of-metadata.md' contains an unrecognized relative link './../../reference/literals/#durations', it was left as is. Did you mean '../reference/literals.md#durations'?
INFO    -  Doc file 'annotation/types-of-metadata.md' contains an unrecognized relative link './../../reference/literals/#dates', it was left as is. Did you mean '../reference/literals.md#dates'?
INFO    -  Doc file 'api/code-reference.md' contains an unrecognized relative link '../../reference/sources', it was left as is. Did you mean '../reference/sources.md'?
INFO    -  Doc file 'api/code-reference.md' contains an unrecognized relative link '../data-array', it was left as is. Did you mean 'data-array.md'?
INFO    -  Doc file 'api/code-reference.md' contains an unrecognized relative link '../data-array', it was left as is. Did you mean 'data-array.md'?
INFO    -  Doc file 'api/code-reference.md' contains an unrecognized relative link '../data-array', it was left as is. Did you mean 'data-array.md'?
INFO    -  Doc file 'api/intro.md' contains an unrecognized relative link '../code-reference/', it was left as is. Did you mean 'code-reference.md'?
INFO    -  Doc file 'api/intro.md' contains an unrecognized relative link '../code-reference/', it was left as is. Did you mean 'code-reference.md'?
INFO    -  Doc file 'queries/data-commands.md' contains an unrecognized relative link '../reference/sources', it was left as is. Did you mean '../reference/sources.md'?
INFO    -  Doc file 'queries/differences-to-sql.md' contains an unrecognized relative link '../../queries/data-commands', it was left as is. Did you mean 'data-commands.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../queries/structure', it was left as is. Did you mean 'structure.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../queries/differences-to-sql', it was left as is. Did you mean 'differences-to-sql.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../queries/structure', it was left as is. Did you mean 'structure.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../resources/examples', it was left as is. Did you mean '../resources/examples.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../reference/expressions', it was left as is. Did you mean '../reference/expressions.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../reference/literals', it was left as is. Did you mean '../reference/literals.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../reference/functions', it was left as is. Did you mean '../reference/functions.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../api/intro', it was left as is. Did you mean '../api/intro.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../api/code-reference', it was left as is. Did you mean '../api/code-reference.md'?
INFO    -  Doc file 'queries/dql-js-inline.md' contains an unrecognized relative link '../../api/code-examples', it was left as is. Did you mean '../api/code-examples.md'?
INFO    -  Doc file 'queries/structure.md' contains an unrecognized relative link '../../queries/differences-to-sql', it was left as is. Did you mean 'differences-to-sql.md'?
INFO    -  Doc file 'queries/structure.md' contains an unrecognized relative link '../../reference/sources', it was left as is. Did you mean '../reference/sources.md'?
INFO    -  Doc file 'queries/structure.md' contains an unrecognized relative link '../../reference/sources', it was left as is. Did you mean '../reference/sources.md'?
INFO    -  Doc file 'reference/expressions.md' contains an unrecognized relative link '../functions', it was left as is. Did you mean 'functions.md'?
INFO    -  Doc file 'reference/literals.md' contains an unrecognized relative link '../functions/#dateany', it was left as is. Did you mean 'functions.md#dateany'?
INFO    -  Doc file 'reference/sources.md' contains an unrecognized relative link '../queries/data-commands#from', it was left as is. Did you mean '../queries/data-commands.md#from'?
INFO    -  Doc file 'resources/faq.md' contains an unrecognized relative link '../../api/code-reference/#dvviewpath-input', it was left as is. Did you mean '../api/code-reference.md#dvviewpath-input'?
INFO    -  Doc file 'resources/faq.md' contains an unrecognized relative link '../../queries/dql-js-inline#inline-dql', it was left as is. Did you mean '../queries/dql-js-inline.md#inline-dql'?
INFO    -  Doc file 'index.md' contains a link 'queries/query-types.md#task-queries', but the doc 'queries/query-types.md' does not contain an anchor '#task-queries'.
INFO    -  Doc file 'annotation/metadata-tasks.md' contains a link '../queries/query-types.md#task-queries', but the doc 'queries/query-types.md' does not contain an anchor '#task-queries'.

Here I've fixed these problems.
I've noticed this problem in some of my under-use softwares, mybe I can make a pull request to `mkdocs` to solve this link problem when change file directory structures.
