### PR TITLE
Bug-fix not needed anymore

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,3 @@
-/** Live Preview padding fixes, specifically for DataviewJS custom HTML elements. */
-.is-live-preview .block-language-dataviewjs > p, .is-live-preview .block-language-dataviewjs > span {
-    line-height: 1.0;
-}
-
 .block-language-dataview {
     overflow-y: auto;
 }


### PR DESCRIPTION
Obsidian seems to have changed rendering the need to correct line spacing unneeded. Originally discovered in #743, and re-visited now in #2519.

Resolves #2519, and resolves #743 which was the original bug.