### PR TITLE
Bug: Handle null values in slice() with multiple arguments

### DIFF
--- a/src/expression/functions.ts
+++ b/src/expression/functions.ts
@@ -877,6 +877,8 @@ export namespace DefaultFunctions {
             return a.slice(start, end);
         })
         .add1("null", () => null)
+        .add2("null", "*", () => null)
+        .add3("null", "*", "*", () => null)
         .build();
 
     // Returns the first non-null value from the array as a single element

--- a/src/test/function/functions.test.ts
+++ b/src/test/function/functions.test.ts
@@ -89,6 +89,9 @@ test("Evaluate slice()", () => {
         "duck",
         "elephant",
     ]); // slice(string list, -3)
+    expect(parseEval("slice(null)")).toEqual(parseEval("null"));
+    expect(parseEval("slice(null, 0)")).toEqual(parseEval("null"));
+    expect(parseEval("slice(null, 0, 1)")).toEqual(parseEval("null"));
 });
 
 // <-- sort() -->


### PR DESCRIPTION
I ran into a bug where I had two notes:

```
Test
---
TestArray: 
---
```

```
Test2
---
TestArray: 
- item a
- item b
---
```

If I run: 
```
dataview
TABLE slice(TestArray)
```
Both notes are returned.

If I run:
```
dataview
TABLE slice(TestArray, 0)
```
Only Test2 is returned.

This behaviour persists even if there's a null check involved on the property. My expectation is that the number of notes returned by the first and second queries would be the same.