### PR TITLE
Bug fix for #2557 Only rendering last item in inline fields in Live Preview

### DIFF
--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -42,7 +42,9 @@ async function renderCompactMarkdownForInlineFieldLivePreview(
     await MarkdownRenderer.render(app, markdown, tmpContainer, sourcePath, component);
     let paragraph = tmpContainer.querySelector(":scope > p");
     if (tmpContainer.childNodes.length == 1 && paragraph) {
-        container.appendChild(paragraph.childNodes.item(paragraph.childNodes.length - 1));
+        while (paragraph.firstChild) {
+            container.appendChild(paragraph.firstChild);
+        }
     } else {
         container.replaceChildren(...tmpContainer.childNodes);
     }


### PR DESCRIPTION
PR #2416 introduced code which only added the last item of a multi-item inline field, to the main view. Now we loop on all the temporary elements adding them back to the main cointainer.