### PR TITLE
Fix inline views not refreshing

### DIFF
--- a/src/ui/views/inline-view.ts
+++ b/src/ui/views/inline-view.ts
@@ -37,6 +37,7 @@ export class DataviewInlineRenderer extends DataviewRefreshableRenderer {
             await renderValue(this.app, result.value, temp, this.origin, this, this.settings, false);
 
             this.target.replaceWith(temp);
+            this.target = temp;
         }
     }
 }


### PR DESCRIPTION
Currently, inline queries do not get periodically refreshed due to a bug in implementation of the refresher class. This PR should address that

Related issues: #1317 & #2340 

This PR addresses both issues, though with concerns over performance & wishes for more targeted & instant refreshing (eg. "Oh we are querying `this.field`? Lets refresh when `this.field` changes`)